### PR TITLE
Fix module syntax errors preventing main rendering

### DIFF
--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -57,25 +57,23 @@ export const ListView = {
     content.appendChild(row);
   }
 };
-  
-// Atualiza ao selecionar tópico
+
 EventBus.on('topicSelected', topic => {
   ListView.render(topic);
 });
 
-// Atualiza quando tarefa for adicionada
 EventBus.on('taskAdded', () => {
   const activeTab = document.querySelector('#tab-topics .nav-link.active');
   const topic = activeTab?.dataset.topic || 'Todos';
   ListView.render(topic);
 });
-// Atualiza quando tarefa for atualizada
+
 EventBus.on('taskUpdated', () => {
   const activeTab = document.querySelector('#tab-topics .nav-link.active');
   const topic = activeTab?.dataset.topic || 'Todos';
   ListView.render(topic);
 });
-// Atualiza quando tarefa for removida
+
 EventBus.on('taskRemoved', () => {
   const activeTab = document.querySelector('#tab-topics .nav-link.active');
   const topic = activeTab?.dataset.topic || 'Todos';

--- a/assets/js/view/modalView.js
+++ b/assets/js/view/modalView.js
@@ -1,4 +1,3 @@
-
 import { TaskModel } from '../model/taskModel.js';
 import { EventBus } from '../core/eventBus.js';
 
@@ -20,9 +19,7 @@ export const ModalView = {
               </div>
               <div class="col-md-6">
                 <label class="form-label">Assunto</label>
-                <select class="form-select" name="topic" required>
-                  ${TaskModel.getTopics().map(t => `<option value="\${t}">\${t}</option>`).join('')}
-                </select>
+                <select class="form-select" name="topic" required></select>
               </div>
               <div class="col-md-6">
                 <label class="form-label">Data de Início</label>
@@ -55,6 +52,7 @@ export const ModalView = {
     </div>`;
 
     document.body.insertAdjacentHTML('beforeend', modalHtml);
+    this.updateTopicOptions();
 
     const form = document.getElementById('taskForm');
     form.addEventListener('submit', (e) => {
@@ -62,7 +60,17 @@ export const ModalView = {
       const data = Object.fromEntries(new FormData(form).entries());
       TaskModel.addTask(data);
       bootstrap.Modal.getInstance(document.getElementById('taskModal')).hide();
+      form.reset();
     });
+  },
+
+  updateTopicOptions() {
+    const select = document.querySelector('#taskForm select[name="topic"]');
+    if (!select) return;
+    const options = TaskModel.getTopics()
+      .map(topic => `<option value="${topic}">${topic}</option>`)
+      .join('');
+    select.innerHTML = options;
   },
 
   open() {
@@ -72,5 +80,7 @@ export const ModalView = {
   }
 };
 
-// Escutar evento global para abrir modal
+EventBus.on('dataLoaded', () => ModalView.updateTopicOptions());
+EventBus.on('taskAdded', () => ModalView.updateTopicOptions());
+EventBus.on('taskUpdated', () => ModalView.updateTopicOptions());
 EventBus.on('openTaskModal', () => ModalView.open());

--- a/assets/js/view/tabsView.js
+++ b/assets/js/view/tabsView.js
@@ -1,5 +1,3 @@
-
-import { TaskModel } from '../model/taskModel.js';
 import { EventBus } from '../core/eventBus.js';
 
 export const TabsView = {
@@ -8,6 +6,8 @@ export const TabsView = {
     ul.innerHTML = '';
 
     const allTopics = ['Todos', ...topics];
+    let firstTopic = allTopics[0];
+
     allTopics.forEach((topic, index) => {
       const li = document.createElement('li');
       li.className = 'nav-item';
@@ -28,10 +28,13 @@ export const TabsView = {
       li.appendChild(a);
       ul.appendChild(li);
     });
+
+    if (firstTopic) {
+      EventBus.emit('topicSelected', firstTopic);
+    }
   }
 };
 
-// Atualiza abas quando os dados forem carregados
 EventBus.on('dataLoaded', (data) => {
   TabsView.render(data.topics);
 });

--- a/assets/js/view/toastView.js
+++ b/assets/js/view/toastView.js
@@ -1,4 +1,3 @@
-
 export const ToastView = {
   init() {
     const toastContainer = document.createElement('div');
@@ -17,12 +16,12 @@ export const ToastView = {
     toast.ariaAtomic = 'true';
     toast.id = toastId;
 
-    toast.innerHTML = \`
+    toast.innerHTML = `
       <div class="d-flex">
-        <div class="toast-body">\${message}</div>
+        <div class="toast-body">${message}</div>
         <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Fechar"></button>
       </div>
-    \`;
+    `;
 
     document.getElementById('toast-container').appendChild(toast);
 


### PR DESCRIPTION
## Summary
- corrigir os template literals dos módulos ToastView e ModalView para evitar erros de sintaxe
- ajustar TabsView para disparar a seleção inicial de tópico e garantir o carregamento da lista
- atualizar ModalView/ListView para popular corretamente os tópicos após carregamento dos dados

## Testing
- não foram executados testes automatizados (não há suíte configurada)


------
https://chatgpt.com/codex/tasks/task_e_68cd0e66ae3083258c8f2bbc299c19e5