### PR TITLE
Fix module syntax errors preventing main rendering

### DIFF
--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -57,25 +57,23 @@ export const ListView = {
     content.appendChild(row);
   }
 };
-  
-// Atualiza ao selecionar tópico
+
 EventBus.on('topicSelected', topic => {
   ListView.render(topic);
 });
 
-// Atualiza quando tarefa for adicionada
 EventBus.on('taskAdded', () => {
   const activeTab = document.querySelector('#tab-topics .nav-link.active');
   const topic = activeTab?.dataset.topic || 'Todos';
   ListView.render(topic);
 });
-// Atualiza quando tarefa for atualizada
+
 EventBus.on('taskUpdated', () => {
   const activeTab = document.querySelector('#tab-topics .nav-link.active');
   const topic = activeTab?.dataset.topic || 'Todos';
   ListView.render(topic);
 });
-// Atualiza quando tarefa for removida
+
 EventBus.on('taskRemoved', () => {
   const activeTab = document.querySelector('#tab-topics .nav-link.active');
   const topic = activeTab?.dataset.topic || 'Todos';

--- a/assets/js/view/modalView.js
+++ b/assets/js/view/modalView.js
@@ -1,4 +1,3 @@
-
 import { TaskModel } from '../model/taskModel.js';
 import { EventBus } from '../core/eventBus.js';
 
@@ -20,9 +19,7 @@ export const ModalView = {
               </div>
               <div class="col-md-6">
                 <label class="form-label">Assunto</label>
-                <select class="form-select" name="topic" required>
-                  ${TaskModel.getTopics().map(t => `<option value="\${t}">\${t}</option>`).join('')}
-                </select>
+                <select class="form-select" name="topic" required></select>
               </div>
               <div class="col-md-6">
                 <label class="form-label">Data de Início</label>
@@ -55,6 +52,7 @@ export const ModalView = {
     </div>`;
 
     document.body.insertAdjacentHTML('beforeend', modalHtml);
+    this.updateTopicOptions();
 
     const form = document.getElementById('taskForm');
     form.addEventListener('submit', (e) => {
@@ -62,7 +60,17 @@ export const ModalView = {
       const data = Object.fromEntries(new FormData(form).entries());
       TaskModel.addTask(data);
       bootstrap.Modal.getInstance(document.getElementById('taskModal')).hide();
+      form.reset();
     });
+  },
+
+  updateTopicOptions() {
+    const select = document.querySelector('#taskForm select[name="topic"]');
+    if (!select) return;
+    const options = TaskModel.getTopics()
+      .map(topic => `<option value="${topic}">${topic}</option>`)
+      .join('');
+    select.innerHTML = options;
   },
 
   open() {
@@ -72,5 +80,7 @@ export const ModalView = {
   }
 };
 
-// Escutar evento global para abrir modal
+EventBus.on('dataLoaded', () => ModalView.updateTopicOptions());
+EventBus.on('taskAdded', () => ModalView.updateTopicOptions());
+EventBus.on('taskUpdated', () => ModalView.updateTopicOptions());
 EventBus.on('openTaskModal', () => ModalView.open());

--- a/assets/js/view/tabsView.js
+++ b/assets/js/view/tabsView.js
@@ -1,5 +1,3 @@
-
-import { TaskModel } from '../model/taskModel.js';
 import { EventBus } from '../core/eventBus.js';
 
 export const TabsView = {
@@ -8,6 +6,8 @@ export const TabsView = {
     ul.innerHTML = '';
 
     const allTopics = ['Todos', ...topics];
+    let firstTopic = allTopics[0];
+
     allTopics.forEach((topic, index) => {
       const li = document.createElement('li');
       li.className = 'nav-item';
@@ -28,10 +28,13 @@ export const TabsView = {
       li.appendChild(a);
       ul.appendChild(li);
     });
+
+    if (firstTopic) {
+      EventBus.emit('topicSelected', firstTopic);
+    }
   }
 };
 
-// Atualiza abas quando os dados forem carregados
 EventBus.on('dataLoaded', (data) => {
   TabsView.render(data.topics);
 });

--- a/assets/js/view/toastView.js
+++ b/assets/js/view/toastView.js
@@ -1,4 +1,3 @@
-
 export const ToastView = {
   init() {
     const toastContainer = document.createElement('div');
@@ -17,12 +16,12 @@ export const ToastView = {
     toast.ariaAtomic = 'true';
     toast.id = toastId;
 
-    toast.innerHTML = \`
+    toast.innerHTML = `
       <div class="d-flex">
-        <div class="toast-body">\${message}</div>
+        <div class="toast-body">${message}</div>
         <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Fechar"></button>
       </div>
-    \`;
+    `;
 
     document.getElementById('toast-container').appendChild(toast);
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "paineltask",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node tests/run-tests.js"
+  }
+}

--- a/tests/helpers/fakeDom.js
+++ b/tests/helpers/fakeDom.js
@@ -1,0 +1,221 @@
+class FakeEvent {
+  constructor(type) {
+    this.type = type;
+    this.defaultPrevented = false;
+  }
+
+  preventDefault() {
+    this.defaultPrevented = true;
+  }
+}
+
+class FakeElement {
+  constructor(tagName, ownerDocument) {
+    this.tagName = tagName.toUpperCase();
+    this.ownerDocument = ownerDocument;
+    this.parent = null;
+    this.children = [];
+    this.dataset = {};
+    this.eventListeners = {};
+    this.style = {};
+    this.attributes = {};
+    this._classes = new Set();
+    this._innerHTML = '';
+    this.textContent = '';
+  }
+
+  appendChild(child) {
+    child.parent = this;
+    if (child.ownerDocument !== this.ownerDocument) {
+      child.ownerDocument = this.ownerDocument;
+    }
+    this.children.push(child);
+    this.ownerDocument._registerTree(child);
+    return child;
+  }
+
+  removeChild(child) {
+    const index = this.children.indexOf(child);
+    if (index !== -1) {
+      this.children.splice(index, 1);
+      child.parent = null;
+      this.ownerDocument._unregisterTree(child);
+    }
+    return child;
+  }
+
+  remove() {
+    if (this.parent) {
+      this.parent.removeChild(this);
+    }
+  }
+
+  set id(value) {
+    this.attributes.id = value;
+    this.ownerDocument._registerElement(this);
+  }
+
+  get id() {
+    return this.attributes.id;
+  }
+
+  set name(value) {
+    this.attributes.name = value;
+  }
+
+  get name() {
+    return this.attributes.name;
+  }
+
+  set className(value) {
+    this._classes = new Set((value || '').split(/\s+/).filter(Boolean));
+  }
+
+  get className() {
+    return Array.from(this._classes).join(' ');
+  }
+
+  get classList() {
+    const element = this;
+    return {
+      add(...classes) {
+        classes.flatMap(cls => cls.split(/\s+/)).filter(Boolean).forEach(cls => element._classes.add(cls));
+      },
+      remove(...classes) {
+        classes.flatMap(cls => cls.split(/\s+/)).filter(Boolean).forEach(cls => element._classes.delete(cls));
+      },
+      contains(cls) {
+        return element._classes.has(cls);
+      }
+    };
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = value;
+    if (value === '') {
+      this.children.slice().forEach(child => child.remove());
+    }
+  }
+
+  get innerHTML() {
+    if (this.children.length > 0) {
+      return this.children.map(child => child.innerHTML || '').join('');
+    }
+    return this._innerHTML;
+  }
+
+  setAttribute(name, value) {
+    if (name === 'id') {
+      this.id = value;
+      return;
+    }
+    if (name === 'class') {
+      this.className = value;
+      return;
+    }
+    this.attributes[name] = value;
+  }
+
+  getAttribute(name) {
+    if (name === 'id') {
+      return this.id || null;
+    }
+    if (name === 'class') {
+      return this.className;
+    }
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  addEventListener(type, handler) {
+    if (!this.eventListeners[type]) {
+      this.eventListeners[type] = [];
+    }
+    this.eventListeners[type].push(handler);
+  }
+
+  dispatchEvent(event) {
+    event.target = this;
+    const listeners = this.eventListeners[event.type] || [];
+    listeners.forEach(listener => listener(event));
+    return !event.defaultPrevented;
+  }
+
+  findDescendants(predicate, results = []) {
+    this.children.forEach(child => {
+      if (predicate(child)) {
+        results.push(child);
+      }
+      child.findDescendants(predicate, results);
+    });
+    return results;
+  }
+}
+
+class FakeDocument {
+  constructor() {
+    this.elementsById = new Map();
+    this.body = new FakeElement('body', this);
+    this._registerTree(this.body);
+  }
+
+  createElement(tagName) {
+    return new FakeElement(tagName, this);
+  }
+
+  getElementById(id) {
+    return this.elementsById.get(id) || null;
+  }
+
+  querySelector(selector) {
+    if (selector === '#taskForm select[name="topic"]') {
+      const form = this.getElementById('taskForm');
+      if (!form) return null;
+      const matches = form.findDescendants(el => el.tagName === 'SELECT' && (el.name === 'topic' || el.getAttribute('name') === 'topic'));
+      return matches[0] || null;
+    }
+    if (selector === '#tab-topics .nav-link.active') {
+      const links = this.querySelectorAll('#tab-topics .nav-link');
+      return links.find(link => link.classList.contains('active')) || null;
+    }
+    return null;
+  }
+
+  querySelectorAll(selector) {
+    if (selector === '#tab-topics .nav-link') {
+      const container = this.getElementById('tab-topics');
+      if (!container) return [];
+      return container.findDescendants(el => el.classList && el.classList.contains('nav-link'));
+    }
+    return [];
+  }
+
+  _registerElement(element) {
+    if (element.id) {
+      this.elementsById.set(element.id, element);
+    }
+  }
+
+  _registerTree(element) {
+    if (element.id) {
+      this.elementsById.set(element.id, element);
+    }
+    element.children.forEach(child => this._registerTree(child));
+  }
+
+  _unregisterTree(element) {
+    if (element.id) {
+      this.elementsById.delete(element.id);
+    }
+    element.children.forEach(child => this._unregisterTree(child));
+  }
+}
+
+export function createFakeDocument() {
+  return new FakeDocument();
+}
+
+export function createEvent(type) {
+  return new FakeEvent(type);
+}

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,227 @@
+import { strict as assert } from 'node:assert';
+import { createFakeDocument, createEvent } from './helpers/fakeDom.js';
+
+// Provide minimal bootstrap stub used by ModalView
+globalThis.bootstrap = {
+  Modal: class {
+    constructor() {}
+    show() {}
+    static getInstance() {
+      return { hide() {} };
+    }
+  }
+};
+
+// Load application modules after globals are prepared
+import { TabsView } from '../assets/js/view/tabsView.js';
+import { ToastView } from '../assets/js/view/toastView.js';
+import { ModalView } from '../assets/js/view/modalView.js';
+import { TaskModel } from '../assets/js/model/taskModel.js';
+import { EventBus } from '../assets/js/core/eventBus.js';
+
+function cloneEvents(events) {
+  const clone = {};
+  for (const [event, handlers] of Object.entries(events)) {
+    clone[event] = handlers.slice();
+  }
+  return clone;
+}
+
+function restoreEvents(snapshot) {
+  EventBus.events = {};
+  for (const [event, handlers] of Object.entries(snapshot)) {
+    EventBus.events[event] = handlers.slice();
+  }
+}
+
+const BASE_EVENTS = cloneEvents(EventBus.events);
+
+class TestRunner {
+  constructor() {
+    this.tests = [];
+  }
+
+  add(name, fn) {
+    this.tests.push({ name, fn });
+  }
+
+  async run() {
+    let passed = 0;
+    for (const { name, fn } of this.tests) {
+      try {
+        await fn();
+        console.log(`\u2714 ${name}`);
+        passed += 1;
+      } catch (error) {
+        console.error(`\u2716 ${name}`);
+        console.error(error);
+      }
+    }
+
+    console.log(`\n${passed}/${this.tests.length} tests passed.`);
+    if (passed !== this.tests.length) {
+      process.exitCode = 1;
+    }
+  }
+}
+
+const runner = new TestRunner();
+
+function test(name, fn) {
+  runner.add(name, fn);
+}
+
+test('TabsView.render cria abas e emite seleção inicial', () => {
+  restoreEvents(BASE_EVENTS);
+  const document = createFakeDocument();
+  globalThis.document = document;
+
+  const tabContainer = document.createElement('ul');
+  tabContainer.id = 'tab-topics';
+  document.body.appendChild(tabContainer);
+
+  const originalEmit = EventBus.emit;
+  const emitted = [];
+  EventBus.emit = function(event, data) {
+    emitted.push({ event, data });
+    const handlers = this.events[event];
+    if (handlers) {
+      handlers.forEach(handler => handler(data));
+    }
+  };
+
+  EventBus.events = {};
+
+  TabsView.render(['Trabalho', 'Pessoal']);
+
+  const links = document.querySelectorAll('#tab-topics .nav-link');
+  assert.equal(links.length, 3, 'deve criar abas para todos os tópicos');
+  assert.equal(links[0].classList.contains('active'), true, 'primeira aba deve iniciar ativa');
+  assert.deepEqual(emitted, [{ event: 'topicSelected', data: 'Todos' }], 'deve emitir tópico "Todos" inicialmente');
+
+  EventBus.emit = originalEmit;
+  restoreEvents(BASE_EVENTS);
+});
+
+test('TabsView.render alterna a aba ativa ao clicar', () => {
+  restoreEvents(BASE_EVENTS);
+  const document = createFakeDocument();
+  globalThis.document = document;
+
+  const tabContainer = document.createElement('ul');
+  tabContainer.id = 'tab-topics';
+  document.body.appendChild(tabContainer);
+
+  const originalEmit = EventBus.emit;
+  const emitted = [];
+  EventBus.emit = function(event, data) {
+    emitted.push({ event, data });
+  };
+
+  EventBus.events = {};
+
+  TabsView.render(['Trabalho']);
+
+  const links = document.querySelectorAll('#tab-topics .nav-link');
+  emitted.length = 0; // limpar evento inicial
+
+  const workLink = links[1];
+  workLink.dispatchEvent(createEvent('click'));
+
+  assert.equal(links[0].classList.contains('active'), false, 'aba "Todos" deve perder a seleção');
+  assert.equal(workLink.classList.contains('active'), true, 'aba clicada deve ficar ativa');
+  assert.deepEqual(emitted, [{ event: 'topicSelected', data: 'Trabalho' }], 'deve emitir o tópico clicado');
+
+  EventBus.emit = originalEmit;
+  restoreEvents(BASE_EVENTS);
+});
+
+test('ModalView.updateTopicOptions popula o select com os tópicos atuais', () => {
+  restoreEvents(BASE_EVENTS);
+  const document = createFakeDocument();
+  globalThis.document = document;
+
+  const form = document.createElement('form');
+  form.id = 'taskForm';
+  const select = document.createElement('select');
+  select.name = 'topic';
+  form.appendChild(select);
+  document.body.appendChild(form);
+
+  const originalGetTopics = TaskModel.getTopics;
+  TaskModel.getTopics = () => ['Frontend', 'Backend'];
+
+  ModalView.updateTopicOptions();
+
+  assert.equal(select.innerHTML, '<option value="Frontend">Frontend</option><option value="Backend">Backend</option>', 'select deve ser preenchido com opções dos tópicos');
+
+  TaskModel.getTopics = originalGetTopics;
+  restoreEvents(BASE_EVENTS);
+});
+
+test('ModalView atualiza opções ao responder aos eventos do EventBus', () => {
+  restoreEvents(BASE_EVENTS);
+  const document = createFakeDocument();
+  globalThis.document = document;
+
+  const form = document.createElement('form');
+  form.id = 'taskForm';
+  const select = document.createElement('select');
+  select.name = 'topic';
+  form.appendChild(select);
+  document.body.appendChild(form);
+
+  const snapshot = cloneEvents(EventBus.events);
+  const modalHandlers = handler => handler.toString().includes('updateTopicOptions');
+  EventBus.events = {
+    dataLoaded: (snapshot.dataLoaded || []).filter(modalHandlers),
+    taskAdded: (snapshot.taskAdded || []).filter(modalHandlers),
+    taskUpdated: (snapshot.taskUpdated || []).filter(modalHandlers)
+  };
+
+  let calls = 0;
+  const originalUpdate = ModalView.updateTopicOptions;
+  ModalView.updateTopicOptions = function(...args) {
+    calls += 1;
+    return originalUpdate.apply(this, args);
+  };
+
+  EventBus.emit('taskAdded');
+  EventBus.emit('taskUpdated');
+  EventBus.emit('dataLoaded', { topics: [] });
+
+  assert.equal(calls, 3, 'updateTopicOptions deve responder aos três eventos monitorados');
+
+  ModalView.updateTopicOptions = originalUpdate;
+  restoreEvents(BASE_EVENTS);
+});
+
+test('ToastView exibe e remove automaticamente a notificação', () => {
+  restoreEvents(BASE_EVENTS);
+  const document = createFakeDocument();
+  globalThis.document = document;
+
+  ToastView.init();
+
+  const timeouts = [];
+  const originalSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (fn, delay) => {
+    timeouts.push({ fn, delay });
+    return delay;
+  };
+
+  ToastView.show('Operação concluída', 'info');
+
+  const container = document.getElementById('toast-container');
+  assert.ok(container, 'container de toast deve existir');
+  assert.equal(container.children.length, 1, 'deve haver um toast visível');
+  assert.ok(container.children[0].innerHTML.includes('Operação concluída'), 'toast deve conter a mensagem informada');
+
+  timeouts.forEach(timeout => timeout.fn());
+  assert.equal(container.children.length, 0, 'toast deve ser removido após o tempo configurado');
+
+  globalThis.setTimeout = originalSetTimeout;
+  restoreEvents(BASE_EVENTS);
+});
+
+await runner.run();


### PR DESCRIPTION
## Summary
- corrigir os template literals dos módulos ToastView e ModalView para evitar erros de sintaxe
- ajustar TabsView para disparar a seleção inicial de tópico e garantir o carregamento da lista
- atualizar ModalView/ListView para popular corretamente os tópicos após carregamento dos dados
- adicionar suíte de testes automatizados sem dependências externas para validar as views de abas, modal e toasts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd0e66ae3083258c8f2bbc299c19e5