### PR TITLE
Fix task modal by loading bootstrap bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>TaskBoard – Lista de Tarefas com Calendário</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="./assets/css/style.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
 </head>
 <body>
   <header class="navbar navbar-expand-lg navbar-dark bg-dark px-3">


### PR DESCRIPTION
## Summary
- add Bootstrap bundle script to index to provide modal functionality required by the add task button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd128585f483258614d73628b9cd69