### PR TITLE
Add topic management interface

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -6,6 +6,7 @@ import { TabsView } from './view/tabsView.js';
 import { ModalView } from './view/modalView.js';
 import { ListView } from './view/listView.js';
 import { ToastView } from './view/toastView.js';
+import { TopicManagerView } from './view/topicManagerView.js';
 import { ExportUtils } from './core/exportUtils.js';
 import { ICSUtils } from './core/icsUtils.js';
 import { EventBus } from './core/eventBus.js';
@@ -13,6 +14,7 @@ import { EventBus } from './core/eventBus.js';
 document.addEventListener('DOMContentLoaded', async () => {
   ToastView.init();
   ModalView.init();
+  TopicManagerView.init();
 
   const modeToggleBtn = document.getElementById('toggle-mode');
   const importBtn = document.getElementById('import-json');

--- a/assets/js/model/taskModel.js
+++ b/assets/js/model/taskModel.js
@@ -9,10 +9,20 @@ export const TaskModel = {
     tasks: []
   },
 
+  ensureDataIntegrity() {
+    if (!Array.isArray(this.data.topics)) {
+      this.data.topics = [];
+    }
+    if (!Array.isArray(this.data.tasks)) {
+      this.data.tasks = [];
+    }
+  },
+
   async init() {
     const loaded = await Storage.load();
     if (loaded) {
       this.data = loaded;
+      this.ensureDataIntegrity();
       EventBus.emit('dataLoaded', this.data);
     }
   },
@@ -42,6 +52,73 @@ export const TaskModel = {
       this.persist();
       EventBus.emit('taskUpdated', updatedTask);
     }
+  },
+
+  getTasksByTopic(topic) {
+    return this.data.tasks.filter(task => task.topic === topic);
+  },
+
+  addTopic(name) {
+    const topicName = name?.trim();
+    if (!topicName) {
+      return { success: false, message: 'Informe um nome válido para o assunto.' };
+    }
+    if (this.data.topics.includes(topicName)) {
+      return { success: false, message: 'Já existe um assunto com este nome.' };
+    }
+    this.data.topics.push(topicName);
+    this.data.topics.sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }));
+    this.persist();
+    EventBus.emit('topicsChanged', { topics: this.data.topics });
+    return { success: true, topic: topicName };
+  },
+
+  renameTopic(oldName, newName) {
+    const nextName = newName?.trim();
+    if (!nextName) {
+      return { success: false, message: 'Informe um nome válido para o assunto.' };
+    }
+    if (!this.data.topics.includes(oldName)) {
+      return { success: false, message: 'O assunto selecionado não existe mais.' };
+    }
+    if (oldName === nextName) {
+      return { success: true, topic: nextName };
+    }
+    if (this.data.topics.includes(nextName)) {
+      return { success: false, message: 'Já existe outro assunto com este nome.' };
+    }
+
+    this.data.topics = this.data.topics.map(topic => topic === oldName ? nextName : topic);
+    const now = new Date().toISOString();
+    this.data.tasks = this.data.tasks.map(task => {
+      if (task.topic === oldName) {
+        return { ...task, topic: nextName, updatedAt: now };
+      }
+      return task;
+    });
+
+    this.data.topics.sort((a, b) => a.localeCompare(b, 'pt-BR', { sensitivity: 'base' }));
+    this.persist();
+    EventBus.emit('topicsChanged', { topics: this.data.topics, forcedActive: nextName });
+    EventBus.emit('tasksBulkUpdated', this.data.tasks);
+    return { success: true, topic: nextName };
+  },
+
+  removeTopic(topicName) {
+    if (!this.data.topics.includes(topicName)) {
+      return { success: false, message: 'O assunto informado não existe.' };
+    }
+
+    this.data.topics = this.data.topics.filter(topic => topic !== topicName);
+    const tasksBefore = this.data.tasks.length;
+    this.data.tasks = this.data.tasks.filter(task => task.topic !== topicName);
+    const removedTasks = tasksBefore - this.data.tasks.length;
+
+    this.persist();
+    EventBus.emit('topicsChanged', { topics: this.data.topics, forcedActive: 'Todos' });
+    EventBus.emit('tasksBulkUpdated', this.data.tasks);
+
+    return { success: true, removedTasks };
   },
 
   persist() {

--- a/assets/js/view/calendarView.js
+++ b/assets/js/view/calendarView.js
@@ -48,3 +48,7 @@ export const CalendarView = {
 EventBus.on('dataLoaded', () => {
   CalendarView.render();
 });
+
+EventBus.on('tasksBulkUpdated', () => {
+  CalendarView.render();
+});

--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -79,3 +79,9 @@ EventBus.on('taskRemoved', () => {
   const topic = activeTab?.dataset.topic || 'Todos';
   ListView.render(topic);
 });
+
+EventBus.on('tasksBulkUpdated', () => {
+  const activeTab = document.querySelector('#tab-topics .nav-link.active');
+  const topic = activeTab?.dataset.topic || 'Todos';
+  ListView.render(topic);
+});

--- a/assets/js/view/modalView.js
+++ b/assets/js/view/modalView.js
@@ -78,10 +78,17 @@ export const ModalView = {
   updateTopicOptions() {
     const select = document.querySelector('#taskForm select[name="topic"]');
     if (!select) return;
-    const options = TaskModel.getTopics()
-      .map(topic => `<option value="${topic}">${topic}</option>`)
-      .join('');
-    select.innerHTML = options;
+    const topics = TaskModel.getTopics();
+    if (topics.length === 0) {
+      select.innerHTML = '<option value="" disabled>Crie um assunto antes de cadastrar tarefas</option>';
+      select.disabled = true;
+    } else {
+      const options = topics
+        .map(topic => `<option value="${topic}">${topic}</option>`)
+        .join('');
+      select.innerHTML = options;
+      select.disabled = false;
+    }
   },
 
   open() {
@@ -95,3 +102,4 @@ EventBus.on('dataLoaded', () => ModalView.updateTopicOptions());
 EventBus.on('taskAdded', () => ModalView.updateTopicOptions());
 EventBus.on('taskUpdated', () => ModalView.updateTopicOptions());
 EventBus.on('openTaskModal', () => ModalView.open());
+EventBus.on('topicsChanged', () => ModalView.updateTopicOptions());

--- a/assets/js/view/tabsView.js
+++ b/assets/js/view/tabsView.js
@@ -1,19 +1,26 @@
 import { EventBus } from '../core/eventBus.js';
 
 export const TabsView = {
-  render(topics) {
+  render(payload) {
+    const { topics, forcedActive } = Array.isArray(payload)
+      ? { topics: payload, forcedActive: null }
+      : { topics: payload?.topics ?? [], forcedActive: payload?.forcedActive ?? null };
+
     const ul = document.getElementById('tab-topics');
+    const previousActive = document.querySelector('#tab-topics .nav-link.active')?.dataset.topic;
     ul.innerHTML = '';
 
     const allTopics = ['Todos', ...topics];
-    let firstTopic = allTopics[0];
+    const currentActive = forcedActive || previousActive;
+    const activeTopic = allTopics.includes(currentActive) ? currentActive : allTopics[0];
 
     allTopics.forEach((topic, index) => {
       const li = document.createElement('li');
       li.className = 'nav-item';
 
       const a = document.createElement('a');
-      a.className = 'nav-link' + (index === 0 ? ' active' : '');
+      const isActive = topic === activeTopic || (!activeTopic && index === 0);
+      a.className = 'nav-link' + (isActive ? ' active' : '');
       a.dataset.topic = topic;
       a.href = '#';
       a.textContent = topic;
@@ -29,12 +36,16 @@ export const TabsView = {
       ul.appendChild(li);
     });
 
-    if (firstTopic) {
-      EventBus.emit('topicSelected', firstTopic);
+    if (activeTopic) {
+      EventBus.emit('topicSelected', activeTopic);
     }
   }
 };
 
 EventBus.on('dataLoaded', (data) => {
   TabsView.render(data.topics);
+});
+
+EventBus.on('topicsChanged', (payload) => {
+  TabsView.render(payload);
 });

--- a/assets/js/view/topicManagerView.js
+++ b/assets/js/view/topicManagerView.js
@@ -1,0 +1,188 @@
+import { TaskModel } from '../model/taskModel.js';
+import { ToastView } from './toastView.js';
+import { EventBus } from '../core/eventBus.js';
+
+export const TopicManagerView = {
+  init() {
+    this.manageBtn = document.getElementById('manage-topics');
+    if (!this.manageBtn) return;
+    this.manageBtn.addEventListener('click', () => this.open());
+    this.renderModal();
+  },
+
+  renderModal() {
+    const modalHtml = `
+    <div class="modal fade" id="topicManagerModal" tabindex="-1" aria-labelledby="topicManagerLabel" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="topicManagerLabel">Gerenciar assuntos</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+          </div>
+          <div class="modal-body">
+            <form id="topic-form" class="row g-2">
+              <div class="col-12">
+                <label for="topic-name-input" class="form-label">Nome do assunto</label>
+                <input type="text" class="form-control" id="topic-name-input" placeholder="Ex: Trabalho, Estudos" required>
+              </div>
+              <div class="col-12 d-flex justify-content-end gap-2">
+                <button type="button" class="btn btn-outline-secondary btn-sm d-none" id="topic-cancel-edit">Cancelar</button>
+                <button type="submit" class="btn btn-primary btn-sm" id="topic-submit-btn">Adicionar assunto</button>
+              </div>
+            </form>
+            <hr>
+            <p class="text-muted small mb-2">Selecione um assunto para editar ou remover. Tarefas de assuntos excluídos também serão apagadas.</p>
+            <ul class="list-group" id="topic-list"></ul>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+          </div>
+        </div>
+      </div>
+    </div>`;
+
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+    this.modalEl = document.getElementById('topicManagerModal');
+    this.listEl = this.modalEl.querySelector('#topic-list');
+    this.formEl = this.modalEl.querySelector('#topic-form');
+    this.inputEl = this.modalEl.querySelector('#topic-name-input');
+    this.submitBtn = this.modalEl.querySelector('#topic-submit-btn');
+    this.cancelEditBtn = this.modalEl.querySelector('#topic-cancel-edit');
+    this.currentTopic = null;
+
+    this.formEl.addEventListener('submit', (event) => {
+      event.preventDefault();
+      this.handleSubmit();
+    });
+
+    this.cancelEditBtn.addEventListener('click', () => this.resetForm());
+
+    this.listEl.addEventListener('click', (event) => {
+      const target = event.target.closest('[data-action]');
+      if (!target) return;
+      const topicIndex = Number.parseInt(target.dataset.topicIndex, 10);
+      if (Number.isNaN(topicIndex)) return;
+      const topics = TaskModel.getTopics();
+      const topicName = topics[topicIndex];
+      if (!topicName) return;
+
+      if (target.dataset.action === 'edit') {
+        this.startEditing(topicName);
+      } else if (target.dataset.action === 'delete') {
+        this.deleteTopic(topicName);
+      }
+    });
+  },
+
+  escapeHtml(value) {
+    if (!value) return '';
+    return value.replace(/[&<>"']/g, (char) => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    })[char]);
+  },
+
+  open() {
+    this.resetForm();
+    this.updateList();
+    const modal = new bootstrap.Modal(this.modalEl);
+    modal.show();
+  },
+
+  updateList() {
+    if (!this.listEl) return;
+    const topics = TaskModel.getTopics();
+    if (topics.length === 0) {
+      this.listEl.innerHTML = '<li class="list-group-item text-muted">Nenhum assunto cadastrado.</li>';
+      return;
+    }
+
+    this.listEl.innerHTML = topics.map((topic, index) => {
+      const safeTopic = this.escapeHtml(topic);
+      return `
+        <li class="list-group-item d-flex align-items-center justify-content-between gap-2">
+          <span class="flex-grow-1">${safeTopic}</span>
+          <div class="btn-group btn-group-sm">
+            <button type="button" class="btn btn-outline-primary" data-action="edit" data-topic-index="${index}">Editar</button>
+            <button type="button" class="btn btn-outline-danger" data-action="delete" data-topic-index="${index}">Excluir</button>
+          </div>
+        </li>`;
+    }).join('');
+  },
+
+  startEditing(topicName) {
+    this.currentTopic = topicName;
+    this.inputEl.value = topicName;
+    this.submitBtn.textContent = 'Salvar alterações';
+    this.cancelEditBtn.classList.remove('d-none');
+    this.inputEl.focus();
+  },
+
+  resetForm() {
+    this.currentTopic = null;
+    this.inputEl.value = '';
+    this.submitBtn.textContent = 'Adicionar assunto';
+    this.cancelEditBtn.classList.add('d-none');
+  },
+
+  handleSubmit() {
+    const value = this.inputEl.value.trim();
+    if (!value) {
+      ToastView.show('Informe um nome para o assunto.', 'warning');
+      return;
+    }
+
+    if (this.currentTopic) {
+      const result = TaskModel.renameTopic(this.currentTopic, value);
+      if (!result.success) {
+        ToastView.show(result.message, 'warning');
+        return;
+      }
+      ToastView.show('Assunto atualizado com sucesso!', 'success');
+    } else {
+      const result = TaskModel.addTopic(value);
+      if (!result.success) {
+        ToastView.show(result.message, 'warning');
+        return;
+      }
+      ToastView.show('Assunto adicionado com sucesso!', 'success');
+    }
+
+    this.resetForm();
+    this.updateList();
+  },
+
+  deleteTopic(topicName) {
+    const tasks = TaskModel.getTasksByTopic(topicName);
+    const hasTasks = tasks.length > 0;
+    const confirmationMessage = hasTasks
+      ? `O assunto "${topicName}" possui ${tasks.length} tarefa(s). Ao prosseguir, elas também serão excluídas. Deseja continuar?`
+      : `Deseja realmente excluir o assunto "${topicName}"?`;
+
+    if (!confirm(confirmationMessage)) {
+      return;
+    }
+
+    const result = TaskModel.removeTopic(topicName);
+    if (!result.success) {
+      ToastView.show(result.message, 'warning');
+      return;
+    }
+
+    const successMessage = result.removedTasks > 0
+      ? `Assunto e ${result.removedTasks} tarefa(s) associada(s) removidos.`
+      : 'Assunto removido com sucesso!';
+
+    ToastView.show(successMessage, 'success');
+    this.resetForm();
+    this.updateList();
+  }
+};
+
+EventBus.on('topicsChanged', () => {
+  TopicManagerView.updateList();
+});

--- a/index.html
+++ b/index.html
@@ -21,7 +21,10 @@
   </header>
 
   <main class="container-fluid mt-3">
-    <ul class="nav nav-tabs" id="tab-topics"></ul>
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+      <ul class="nav nav-tabs flex-grow-1" id="tab-topics"></ul>
+      <button id="manage-topics" class="btn btn-outline-primary btn-sm">Gerenciar assuntos</button>
+    </div>
     <div class="tab-content mt-3" id="tab-content"></div>
     <div id="calendar-view" class="d-none"></div>
   </main>


### PR DESCRIPTION
## Summary
- add a Bootstrap modal to manage topics, with actions to create, edit and remove subjects
- extend the task model and tabs view to react to topic CRUD events and keep the UI in sync
- disable task creation when no topics exist and refresh list/calendar when topics change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd1b6842ac8325b3717cc416937669