### PR TITLE
Show task detail modal when clicking task cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -18,3 +18,15 @@ body {
   font-weight: bold;
   font-size: 0.9rem;
 }
+
+.task-card {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.task-card:hover,
+.task-card:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  outline: none;
+}

--- a/assets/js/controller/appController.js
+++ b/assets/js/controller/appController.js
@@ -24,8 +24,8 @@ export const AppController = {
       ToastView.show('Tarefa atualizada com sucesso!', 'info');
     });
 
-    EventBus.on('openTaskModal', () => {
-      ModalView.open();
+    EventBus.on('openTaskModal', (task) => {
+      ModalView.open(task);
     });
 
     await TaskModel.init();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,6 +5,7 @@ import { CalendarView } from './view/calendarView.js';
 import { TabsView } from './view/tabsView.js';
 import { ModalView } from './view/modalView.js';
 import { ListView } from './view/listView.js';
+import { TaskDetailView } from './view/taskDetailView.js';
 import { ToastView } from './view/toastView.js';
 import { ExportUtils } from './core/exportUtils.js';
 import { ICSUtils } from './core/icsUtils.js';
@@ -13,6 +14,7 @@ import { EventBus } from './core/eventBus.js';
 document.addEventListener('DOMContentLoaded', async () => {
   ToastView.init();
   ModalView.init();
+  TaskDetailView.init();
 
   const modeToggleBtn = document.getElementById('toggle-mode');
   const importBtn = document.getElementById('import-json');
@@ -84,5 +86,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   EventBus.on('taskAdded', () => {
     ToastView.show('Tarefa salva com sucesso!', 'success');
+  });
+
+  EventBus.on('taskUpdated', () => {
+    ToastView.show('Tarefa atualizada com sucesso!', 'info');
+  });
+
+  EventBus.on('taskRemoved', () => {
+    ToastView.show('Tarefa excluída com sucesso!', 'warning');
   });
 });

--- a/assets/js/model/taskModel.js
+++ b/assets/js/model/taskModel.js
@@ -25,6 +25,10 @@ export const TaskModel = {
     return this.data.topics;
   },
 
+  getTaskById(id) {
+    return this.data.tasks.find(task => task.id === id);
+  },
+
   addTask(task) {
     task.id = `t-${Date.now()}`;
     task.createdAt = new Date().toISOString();
@@ -41,6 +45,15 @@ export const TaskModel = {
       this.data.tasks[index] = updatedTask;
       this.persist();
       EventBus.emit('taskUpdated', updatedTask);
+    }
+  },
+
+  removeTask(id) {
+    const index = this.data.tasks.findIndex(task => task.id === id);
+    if (index !== -1) {
+      const [removedTask] = this.data.tasks.splice(index, 1);
+      this.persist();
+      EventBus.emit('taskRemoved', removedTask);
     }
   },
 

--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -34,19 +34,55 @@ export const ListView = {
 
       filtered.filter(t => t.status === status).forEach(task => {
         const card = document.createElement('div');
-        card.className = 'card mb-2';
-        card.innerHTML = `
-          <div class="card-body p-2">
-            <h6 class="card-title mb-1">${task.title}</h6>
-            <small class="text-muted">${task.dueDate || 'Sem data'}</small>
-            <div class="mt-1">
-              <span class="badge bg-secondary">${task.topic}</span>
-              <span class="badge bg-${task.priority === 'high' ? 'danger' : task.priority === 'medium' ? 'warning' : 'light'} text-dark">
-                ${task.priority}
-              </span>
-            </div>
-          </div>
-        `;
+        card.className = 'card mb-2 task-card';
+        card.tabIndex = 0;
+        card.setAttribute('role', 'button');
+
+        const body = document.createElement('div');
+        body.className = 'card-body p-2';
+
+        const title = document.createElement('h6');
+        title.className = 'card-title mb-1';
+        title.textContent = task.title;
+
+        const date = document.createElement('small');
+        date.className = 'text-muted';
+        date.textContent = task.dueDate || 'Sem data';
+
+        const meta = document.createElement('div');
+        meta.className = 'mt-1 d-flex flex-wrap gap-1';
+
+        const topicBadge = document.createElement('span');
+        topicBadge.className = 'badge bg-secondary';
+        topicBadge.textContent = task.topic;
+
+        const priorityBadge = document.createElement('span');
+        const priorityClasses = {
+          high: 'badge bg-danger',
+          medium: 'badge bg-warning text-dark',
+          low: 'badge bg-light text-dark'
+        };
+        priorityBadge.className = priorityClasses[task.priority] || 'badge bg-light text-dark';
+        priorityBadge.textContent = task.priority;
+
+        meta.appendChild(topicBadge);
+        meta.appendChild(priorityBadge);
+
+        body.appendChild(title);
+        body.appendChild(date);
+        body.appendChild(meta);
+
+        card.appendChild(body);
+        card.addEventListener('click', () => {
+          EventBus.emit('openTaskDetail', task);
+        });
+        card.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            EventBus.emit('openTaskDetail', task);
+          }
+        });
+
         box.appendChild(card);
       });
 

--- a/assets/js/view/taskDetailView.js
+++ b/assets/js/view/taskDetailView.js
@@ -1,0 +1,152 @@
+import { EventBus } from '../core/eventBus.js';
+import { TaskModel } from '../model/taskModel.js';
+
+export const TaskDetailView = {
+  modal: null,
+  modalEl: null,
+  currentTask: null,
+
+  init() {
+    const modalHtml = `
+      <div class="modal fade" id="taskDetailModal" tabindex="-1" aria-labelledby="taskDetailModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="taskDetailModalLabel">Detalhes da Tarefa</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+              <div class="mb-3">
+                <h6 class="fw-bold">Título</h6>
+                <p class="mb-0" data-detail="title"></p>
+              </div>
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <h6 class="fw-bold">Assunto</h6>
+                  <p class="mb-0" data-detail="topic"></p>
+                </div>
+                <div class="col-md-3">
+                  <h6 class="fw-bold">Início</h6>
+                  <p class="mb-0" data-detail="startDate"></p>
+                </div>
+                <div class="col-md-3">
+                  <h6 class="fw-bold">Fim</h6>
+                  <p class="mb-0" data-detail="dueDate"></p>
+                </div>
+              </div>
+              <div class="mt-3">
+                <h6 class="fw-bold">Prioridade</h6>
+                <span class="badge" data-detail="priority"></span>
+              </div>
+              <div class="mt-3">
+                <h6 class="fw-bold">Tags</h6>
+                <div class="d-flex flex-wrap gap-2" data-detail="tags"></div>
+              </div>
+              <div class="mt-3">
+                <h6 class="fw-bold">Notas</h6>
+                <p class="mb-0" data-detail="notes"></p>
+              </div>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+              <button type="button" class="btn btn-outline-danger" data-action="delete">Excluir</button>
+              <div class="d-flex gap-2">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Fechar</button>
+                <button type="button" class="btn btn-primary" data-action="edit">Editar</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+    this.modalEl = document.getElementById('taskDetailModal');
+    this.modal = new bootstrap.Modal(this.modalEl);
+
+    this.modalEl.querySelector('[data-action="edit"]').addEventListener('click', () => {
+      if (!this.currentTask) return;
+      this.modal.hide();
+      EventBus.emit('openTaskModal', this.currentTask);
+    });
+
+    this.modalEl.querySelector('[data-action="delete"]').addEventListener('click', () => {
+      if (!this.currentTask) return;
+      if (confirm('Deseja excluir esta tarefa?')) {
+        TaskModel.removeTask(this.currentTask.id);
+        this.modal.hide();
+      }
+    });
+
+    this.modalEl.addEventListener('hidden.bs.modal', () => {
+      this.currentTask = null;
+      this.clearDetails();
+    });
+
+    EventBus.on('openTaskDetail', task => this.open(task));
+  },
+
+  open(task) {
+    if (!task) return;
+    const latestTask = TaskModel.getTaskById(task.id);
+    this.currentTask = latestTask ? { ...latestTask } : { ...task };
+
+    this.fillDetails(this.currentTask);
+    this.modal.show();
+  },
+
+  fillDetails(task) {
+    this.setText('title', task.title || '—');
+    this.setText('topic', task.topic || '—');
+    this.setText('startDate', task.startDate || '—');
+    this.setText('dueDate', task.dueDate || '—');
+
+    const priorityEl = this.modalEl.querySelector('[data-detail="priority"]');
+    const priorityLabels = {
+      high: { text: 'Alta', className: 'bg-danger' },
+      medium: { text: 'Média', className: 'bg-warning text-dark' },
+      low: { text: 'Baixa', className: 'bg-secondary' }
+    };
+    const priorityInfo = priorityLabels[task.priority] || { text: task.priority || '—', className: 'bg-light text-dark' };
+    priorityEl.className = `badge ${priorityInfo.className}`;
+    priorityEl.textContent = priorityInfo.text;
+
+    const tagsContainer = this.modalEl.querySelector('[data-detail="tags"]');
+    tagsContainer.innerHTML = '';
+    if (Array.isArray(task.tags) && task.tags.length > 0) {
+      task.tags.forEach(tag => {
+        const span = document.createElement('span');
+        span.className = 'badge bg-light text-dark';
+        span.textContent = tag;
+        tagsContainer.appendChild(span);
+      });
+    } else {
+      const span = document.createElement('span');
+      span.className = 'text-muted';
+      span.textContent = 'Sem tags';
+      tagsContainer.appendChild(span);
+    }
+
+    this.setText('notes', task.notes || 'Sem notas');
+  },
+
+  clearDetails() {
+    this.modalEl.querySelectorAll('[data-detail]').forEach(el => {
+      if (el.tagName === 'DIV' || el.tagName === 'SPAN') {
+        el.innerHTML = '';
+      } else {
+        el.textContent = '';
+      }
+    });
+    const priorityEl = this.modalEl.querySelector('[data-detail="priority"]');
+    if (priorityEl) {
+      priorityEl.className = 'badge';
+    }
+  },
+
+  setText(attribute, text) {
+    const element = this.modalEl.querySelector(`[data-detail="${attribute}"]`);
+    if (element) {
+      element.textContent = text;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- make task cards clickable so they open a detail view modal instead of inline buttons
- add a responsive Bootstrap modal to show task details and expose edit/delete controls inside it
- style the task cards for hover/focus feedback and initialize the new detail view during app bootstrap

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd1b09a9148325a687513cd00f7d12