### PR TITLE
Make calendar tasks interactive and improve layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,10 +10,31 @@ body {
 
 .calendar-day-cell {
   min-height: 120px;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .calendar-day-cell .badge {
   white-space: normal;
+}
+
+.calendar-day-tasks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1 1 auto;
+}
+
+.calendar-task-badge {
+  cursor: pointer;
+  white-space: normal;
+}
+
+.calendar-task-badge:focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
 }
 
 .task-card {

--- a/assets/js/view/calendarView.js
+++ b/assets/js/view/calendarView.js
@@ -151,12 +151,12 @@ export const CalendarView = {
 
         if (dayTasks.length > 0) {
           const list = document.createElement('div');
-          list.className = 'd-flex flex-column gap-1 mt-2';
+          list.className = 'calendar-day-tasks mt-2';
 
           dayTasks.forEach(task => {
             const badge = document.createElement('span');
             const badgeClass = STATUS_BADGE[task.status] || 'text-bg-primary';
-            badge.className = `badge ${badgeClass} d-block text-start text-wrap w-100`;
+            badge.className = `badge ${badgeClass} d-block text-start text-wrap w-100 calendar-task-badge`;
             badge.textContent = this._formatTaskLabel(task);
             const periodLabel = this._formatTaskPeriod(task);
             if (periodLabel) {
@@ -164,6 +164,19 @@ export const CalendarView = {
             } else {
               badge.title = task.title;
             }
+
+            badge.tabIndex = 0;
+            badge.setAttribute('role', 'button');
+            badge.addEventListener('click', () => {
+              EventBus.emit('openTaskDetail', task);
+            });
+            badge.addEventListener('keydown', event => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                EventBus.emit('openTaskDetail', task);
+              }
+            });
+
             list.appendChild(badge);
           });
 


### PR DESCRIPTION
## Summary
- adjust calendar day cell layout so all days keep a consistent base size while expanding with responsive task lists
- render day task badges with dedicated styles and keyboard focus handling
- allow selecting tasks directly from the calendar to open the task detail modal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd27a5ec008325969060bf90c2503c