### PR TITLE
Add topic management modal and update topic workflows

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -10,11 +10,13 @@ import { ToastView } from './view/toastView.js';
 import { ExportUtils } from './core/exportUtils.js';
 import { ICSUtils } from './core/icsUtils.js';
 import { EventBus } from './core/eventBus.js';
+import { TopicManagerView } from './view/topicManagerView.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   ToastView.init();
   ModalView.init();
   TaskDetailView.init();
+  TopicManagerView.init();
 
   const modeToggleBtn = document.getElementById('toggle-mode');
   const importBtn = document.getElementById('import-json');
@@ -94,5 +96,30 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   EventBus.on('taskRemoved', () => {
     ToastView.show('Tarefa excluída com sucesso!', 'warning');
+  });
+
+  EventBus.on('topicAdded', (topic) => {
+    ToastView.show(`Assunto "${topic}" criado com sucesso!`, 'success');
+  });
+
+  EventBus.on('topicUpdated', ({ newTopic, updatedCount }) => {
+    const suffix = updatedCount > 0
+      ? ` ${updatedCount} tarefa(s) atualizada(s).`
+      : '';
+    ToastView.show(`Assunto atualizado para "${newTopic}".${suffix}`, 'info');
+  });
+
+  EventBus.on('topicRemoved', ({ topic, replacement, reassignedCount, createdFallback }) => {
+    let message = `Assunto "${topic}" removido.`;
+
+    if (reassignedCount > 0) {
+      message += ` ${reassignedCount} tarefa(s) movida(s) para "${replacement}".`;
+    }
+
+    if (createdFallback) {
+      message += ' Criamos automaticamente um assunto padrão para você continuar organizando as tarefas.';
+    }
+
+    ToastView.show(message, 'warning');
   });
 });

--- a/assets/js/model/taskModel.js
+++ b/assets/js/model/taskModel.js
@@ -2,6 +2,13 @@
 import { Storage } from '../core/storage.js';
 import { EventBus } from '../core/eventBus.js';
 
+const FALLBACK_TOPIC = 'Geral';
+
+const normalizeTopicName = (topic) =>
+  typeof topic === 'string' ? topic.trim() : '';
+
+const nowISO = () => new Date().toISOString();
+
 export const TaskModel = {
   data: {
     meta: {},
@@ -13,8 +20,23 @@ export const TaskModel = {
     const loaded = await Storage.load();
     if (loaded) {
       this.data = loaded;
-      EventBus.emit('dataLoaded', this.data);
     }
+
+    if (!Array.isArray(this.data.topics)) {
+      this.data.topics = [];
+    }
+
+    if (!Array.isArray(this.data.tasks)) {
+      this.data.tasks = [];
+    }
+
+    if (this.data.topics.length === 0) {
+      this.data.topics.push(FALLBACK_TOPIC);
+    }
+
+    this._ensureTasksHaveValidTopics();
+
+    EventBus.emit('dataLoaded', this.data);
   },
 
   getTasks() {
@@ -30,9 +52,13 @@ export const TaskModel = {
   },
 
   addTask(task) {
+    const topic = this._resolveExistingTopic(task.topic) || this.data.topics[0] || FALLBACK_TOPIC;
+
     task.id = `t-${Date.now()}`;
-    task.createdAt = new Date().toISOString();
-    task.updatedAt = new Date().toISOString();
+    task.topic = topic;
+    task.createdAt = nowISO();
+    task.updatedAt = nowISO();
+
     this.data.tasks.push(task);
     this.persist();
     EventBus.emit('taskAdded', task);
@@ -41,8 +67,12 @@ export const TaskModel = {
   updateTask(updatedTask) {
     const index = this.data.tasks.findIndex(t => t.id === updatedTask.id);
     if (index !== -1) {
-      updatedTask.updatedAt = new Date().toISOString();
+      const topic = this._resolveExistingTopic(updatedTask.topic) || this.data.topics[0] || FALLBACK_TOPIC;
+
+      updatedTask.topic = topic;
+      updatedTask.updatedAt = nowISO();
       this.data.tasks[index] = updatedTask;
+
       this.persist();
       EventBus.emit('taskUpdated', updatedTask);
     }
@@ -57,7 +87,151 @@ export const TaskModel = {
     }
   },
 
+  addTopic(name) {
+    const topic = normalizeTopicName(name);
+    if (!topic) {
+      return { success: false, reason: 'empty' };
+    }
+
+    if (this._findTopicInsensitive(topic)) {
+      return { success: false, reason: 'duplicate' };
+    }
+
+    this.data.topics.push(topic);
+    this.persist();
+
+    EventBus.emit('topicAdded', topic);
+    EventBus.emit('topicsChanged', [...this.data.topics]);
+
+    return { success: true, topic };
+  },
+
+  updateTopic(oldName, newName) {
+    const currentTopic = this._findTopicInsensitive(oldName);
+    if (!currentTopic) {
+      return { success: false, reason: 'notfound' };
+    }
+
+    const topicIndex = this.data.topics.indexOf(currentTopic);
+    const newTopic = normalizeTopicName(newName);
+
+    if (!newTopic) {
+      return { success: false, reason: 'empty' };
+    }
+
+    const existing = this._findTopicInsensitive(newTopic);
+    if (existing && existing !== currentTopic) {
+      return { success: false, reason: 'duplicate' };
+    }
+
+    if (currentTopic === newTopic) {
+      return { success: false, reason: 'unchanged' };
+    }
+
+    this.data.topics[topicIndex] = newTopic;
+
+    let updatedCount = 0;
+    this.data.tasks.forEach(task => {
+      if (task.topic === currentTopic) {
+        task.topic = newTopic;
+        task.updatedAt = nowISO();
+        updatedCount++;
+      }
+    });
+
+    this.persist();
+
+    EventBus.emit('topicUpdated', { oldTopic: currentTopic, newTopic, updatedCount });
+    EventBus.emit('topicsChanged', [...this.data.topics]);
+
+    if (updatedCount > 0) {
+      EventBus.emit('tasksBulkUpdated', [...this.data.tasks]);
+    }
+
+    return { success: true, newTopic, updatedCount };
+  },
+
+  removeTopic(name) {
+    const topic = this._findTopicInsensitive(name);
+    if (!topic) {
+      return { success: false, reason: 'notfound' };
+    }
+
+    const remainingTopics = this.data.topics.filter(t => t !== topic);
+    let replacement = remainingTopics[0];
+    let createdFallback = false;
+
+    if (!replacement) {
+      replacement = FALLBACK_TOPIC;
+      createdFallback = true;
+      remainingTopics.push(replacement);
+    }
+
+    this.data.topics = remainingTopics;
+
+    let reassignedCount = 0;
+    this.data.tasks.forEach(task => {
+      if (task.topic === topic) {
+        task.topic = replacement;
+        task.updatedAt = nowISO();
+        reassignedCount++;
+      }
+    });
+
+    this.persist();
+
+    EventBus.emit('topicRemoved', {
+      topic,
+      replacement,
+      reassignedCount,
+      createdFallback
+    });
+
+    EventBus.emit('topicsChanged', [...this.data.topics]);
+
+    if (reassignedCount > 0) {
+      EventBus.emit('tasksBulkUpdated', [...this.data.tasks]);
+    }
+
+    return { success: true, replacement, reassignedCount, createdFallback };
+  },
+
   persist() {
     Storage.save(this.data);
+  },
+
+  _ensureTasksHaveValidTopics() {
+    const validTopics = new Set(this.data.topics);
+    if (validTopics.size === 0) {
+      const fallback = FALLBACK_TOPIC;
+      this.data.topics = [fallback];
+      validTopics.add(fallback);
+    }
+
+    const fallbackTopic = this.data.topics[0];
+    let needsPersist = false;
+
+    this.data.tasks.forEach(task => {
+      const resolved = this._resolveExistingTopic(task.topic) || fallbackTopic;
+      if (task.topic !== resolved) {
+        task.topic = resolved;
+        task.updatedAt = nowISO();
+        needsPersist = true;
+      }
+    });
+
+    if (needsPersist) {
+      this.persist();
+    }
+  },
+
+  _findTopicInsensitive(topicName) {
+    if (!topicName) return undefined;
+    const normalized = normalizeTopicName(topicName).toLowerCase();
+    return this.data.topics.find(topic => topic.toLowerCase() === normalized);
+  },
+
+  _resolveExistingTopic(topicName) {
+    return this._findTopicInsensitive(topicName);
   }
 };

--- a/assets/js/view/calendarView.js
+++ b/assets/js/view/calendarView.js
@@ -252,3 +252,7 @@ EventBus.on('taskUpdated', () => {
 EventBus.on('taskRemoved', () => {
   CalendarView.render();
 });
+
+EventBus.on('tasksBulkUpdated', () => {
+  CalendarView.render(CalendarView.currentMonth, CalendarView.currentTopic);
+});

--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -116,3 +116,9 @@ EventBus.on('taskRemoved', () => {
   const topic = activeTab?.dataset.topic || 'Todos';
   ListView.render(topic);
 });
+
+EventBus.on('tasksBulkUpdated', () => {
+  const activeTab = document.querySelector('#tab-topics .nav-link.active');
+  const topic = activeTab?.dataset.topic || 'Todos';
+  ListView.render(topic);
+});

--- a/assets/js/view/modalView.js
+++ b/assets/js/view/modalView.js
@@ -150,4 +150,5 @@ export const ModalView = {
 EventBus.on('dataLoaded', () => ModalView.updateTopicOptions());
 EventBus.on('taskAdded', () => ModalView.updateTopicOptions());
 EventBus.on('taskUpdated', () => ModalView.updateTopicOptions());
+EventBus.on('topicsChanged', () => ModalView.updateTopicOptions());
 EventBus.on('openTaskModal', (task) => ModalView.open(task));

--- a/assets/js/view/topicManagerView.js
+++ b/assets/js/view/topicManagerView.js
@@ -1,0 +1,180 @@
+import { TaskModel } from '../model/taskModel.js';
+import { EventBus } from '../core/eventBus.js';
+import { ToastView } from './toastView.js';
+
+export const TopicManagerView = {
+  modal: null,
+  modalEl: null,
+  listEl: null,
+  formEl: null,
+  inputEl: null,
+
+  init() {
+    const manageButton = document.getElementById('manage-topics');
+    if (!manageButton) return;
+
+    this._injectModal();
+
+    manageButton.addEventListener('click', () => {
+      this.open();
+    });
+
+    EventBus.on('dataLoaded', () => this.render());
+    EventBus.on('topicsChanged', () => this.render());
+  },
+
+  _injectModal() {
+    if (this.modalEl) return;
+
+    const modalHtml = `
+      <div class="modal fade" id="topicManagerModal" tabindex="-1" aria-labelledby="topicManagerLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="topicManagerLabel">Gerenciar Assuntos</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+              <form id="topicManagerForm" class="row g-2">
+                <div class="col-12">
+                  <label class="form-label" for="topicManagerInput">Adicionar novo assunto</label>
+                  <div class="input-group">
+                    <input type="text" class="form-control" id="topicManagerInput" placeholder="ex: Pessoal" required>
+                    <button class="btn btn-primary" type="submit">Adicionar</button>
+                  </div>
+                </div>
+              </form>
+              <div class="mt-4">
+                <h6 class="fw-semibold">Assuntos existentes</h6>
+                <div data-topic-list class="list-group"></div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+    this.modalEl = document.getElementById('topicManagerModal');
+    this.modal = new bootstrap.Modal(this.modalEl);
+    this.listEl = this.modalEl.querySelector('[data-topic-list]');
+    this.formEl = this.modalEl.querySelector('#topicManagerForm');
+    this.inputEl = this.modalEl.querySelector('#topicManagerInput');
+
+    this.modalEl.addEventListener('shown.bs.modal', () => {
+      this.inputEl?.focus();
+    });
+
+    this.formEl.addEventListener('submit', (event) => {
+      event.preventDefault();
+      this._handleAddTopic();
+    });
+  },
+
+  open() {
+    if (!this.modal) return;
+    this.render();
+    this.modal.show();
+  },
+
+  render() {
+    if (!this.listEl) return;
+    const topics = TaskModel.getTopics();
+    this.listEl.innerHTML = '';
+
+    if (!Array.isArray(topics) || topics.length === 0) {
+      const emptyItem = document.createElement('div');
+      emptyItem.className = 'list-group-item text-muted';
+      emptyItem.textContent = 'Nenhum assunto cadastrado.';
+      this.listEl.appendChild(emptyItem);
+      return;
+    }
+
+    topics.forEach(topic => {
+      const item = document.createElement('div');
+      item.className = 'list-group-item d-flex justify-content-between align-items-center';
+
+      const title = document.createElement('span');
+      title.textContent = topic;
+      title.className = 'me-3';
+
+      const actions = document.createElement('div');
+      actions.className = 'btn-group btn-group-sm';
+
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.className = 'btn btn-outline-secondary';
+      editBtn.textContent = 'Renomear';
+      editBtn.addEventListener('click', () => {
+        this._handleRenameTopic(topic);
+      });
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'btn btn-outline-danger';
+      deleteBtn.textContent = 'Excluir';
+      deleteBtn.addEventListener('click', () => {
+        this._handleRemoveTopic(topic);
+      });
+
+      actions.appendChild(editBtn);
+      actions.appendChild(deleteBtn);
+
+      item.appendChild(title);
+      item.appendChild(actions);
+      this.listEl.appendChild(item);
+    });
+  },
+
+  _handleAddTopic() {
+    const value = this.inputEl?.value ?? '';
+    const result = TaskModel.addTopic(value);
+
+    if (!result.success) {
+      this._showError(result.reason);
+      return;
+    }
+
+    this.inputEl.value = '';
+  },
+
+  _handleRenameTopic(topic) {
+    const newName = prompt('Informe o novo nome para o assunto:', topic);
+    if (newName === null) {
+      return;
+    }
+
+    const result = TaskModel.updateTopic(topic, newName);
+    if (!result.success) {
+      this._showError(result.reason);
+    }
+  },
+
+  _handleRemoveTopic(topic) {
+    const confirmation = confirm(`Deseja realmente excluir o assunto "${topic}"?`);
+    if (!confirmation) {
+      return;
+    }
+
+    const result = TaskModel.removeTopic(topic);
+    if (!result.success) {
+      this._showError(result.reason);
+    }
+  },
+
+  _showError(reason) {
+    const messages = {
+      empty: 'Informe um nome válido para o assunto.',
+      duplicate: 'Já existe um assunto com esse nome.',
+      notfound: 'Assunto não encontrado.',
+      unchanged: 'O assunto já possui esse nome.'
+    };
+
+    const message = messages[reason] || 'Não foi possível completar a ação.';
+    ToastView.show(message, 'danger');
+  }
+};

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       <button id="import-json" class="btn btn-outline-light btn-sm">Importar JSON</button>
       <button id="export-json" class="btn btn-outline-light btn-sm">Exportar JSON</button>
       <button id="export-ics" class="btn btn-outline-light btn-sm">Exportar ICS</button>
+      <button id="manage-topics" class="btn btn-outline-info btn-sm">Gerenciar Assuntos</button>
       <button id="toggle-mode" class="btn btn-outline-warning btn-sm">Modo: Local</button>
       <input type="file" id="json-file" accept=".json" hidden />
     </div>


### PR DESCRIPTION
## Summary
- add a "Gerenciar Assuntos" action that opens a modal for creating, renaming and removing topics
- extend the task model to support topic CRUD operations and keep tasks aligned with topic changes
- refresh calendar/list views and toast feedback whenever topics change so the UI stays in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2a55ccd48325a57457730c10b07a