### PR TITLE
Fix calendar day cell sizing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -9,7 +9,34 @@ body {
 }
 
 .calendar-day-cell {
-  min-height: 120px;
+  height: 160px;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: hidden;
+}
+
+.calendar-day-header {
+  flex: 0 0 auto;
+}
+
+.calendar-day-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.calendar-day-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.calendar-day-content::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
 }
 
 .calendar-day-cell .badge {

--- a/assets/js/view/calendarView.js
+++ b/assets/js/view/calendarView.js
@@ -130,7 +130,7 @@ export const CalendarView = {
         }
 
         const dayHeader = document.createElement('div');
-        dayHeader.className = 'd-flex justify-content-between align-items-start';
+        dayHeader.className = 'calendar-day-header d-flex justify-content-between align-items-start';
 
         const dayNumber = document.createElement('span');
         dayNumber.className = 'fw-semibold small';
@@ -147,11 +147,14 @@ export const CalendarView = {
 
         cell.appendChild(dayHeader);
 
+        const content = document.createElement('div');
+        content.className = 'calendar-day-content';
+
         const dayTasks = tasks.filter(task => this._isTaskInDay(task, day));
 
         if (dayTasks.length > 0) {
           const list = document.createElement('div');
-          list.className = 'd-flex flex-column gap-1 mt-2';
+          list.className = 'calendar-day-task-list d-flex flex-column gap-1';
 
           dayTasks.forEach(task => {
             const badge = document.createElement('span');
@@ -167,8 +170,10 @@ export const CalendarView = {
             list.appendChild(badge);
           });
 
-          cell.appendChild(list);
+          content.appendChild(list);
         }
+
+        cell.appendChild(content);
 
         row.appendChild(cell);
       });


### PR DESCRIPTION
## Summary
- fix calendar day cells to use a fixed height while keeping headers visible
- add scrollable task list container within each calendar day
- enhance styling for consistent spacing and custom scrollbars

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2e1dd9bc83259a4f0b7c933610b9