### PR TITLE
feat: add ICS import support

### DIFF
--- a/assets/js/core/icsUtils.js
+++ b/assets/js/core/icsUtils.js
@@ -1,6 +1,157 @@
 
 import { TaskModel } from '../model/taskModel.js';
 
+const STATUS_MAP = {
+  completed: 'done',
+  cancelled: 'todo',
+  tentative: 'todo',
+  'in-process': 'doing'
+};
+
+const unfoldLines = (text) => {
+  return text
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .reduce((acc, line) => {
+      if (/^[ \t]/.test(line) && acc.length > 0) {
+        acc[acc.length - 1] += line.trim();
+      } else {
+        acc.push(line.trim());
+      }
+      return acc;
+    }, [])
+    .filter(Boolean);
+};
+
+const parseProperty = (raw) => {
+  const segments = raw.split(';');
+  const key = segments[0].toUpperCase();
+  const params = {};
+
+  segments.slice(1).forEach(segment => {
+    const [paramKey, paramValue] = segment.split('=');
+    if (paramKey && paramValue) {
+      params[paramKey.toUpperCase()] = paramValue;
+    }
+  });
+
+  return { key, params };
+};
+
+const decodeICSString = (value = '') =>
+  value
+    .replace(/\\n/g, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\');
+
+const parseICSDate = (field) => {
+  if (!field || !field.value) {
+    return { date: null, allDay: false };
+  }
+
+  let raw = field.value.trim();
+  if (!raw) {
+    return { date: null, allDay: false };
+  }
+
+  const allDay = field.params.VALUE === 'DATE' || !raw.includes('T');
+  raw = raw.replace('Z', '');
+  const datePart = raw.slice(0, 8);
+
+  if (datePart.length !== 8 || /\D/.test(datePart)) {
+    return { date: null, allDay };
+  }
+
+  const date = `${datePart.slice(0, 4)}-${datePart.slice(4, 6)}-${datePart.slice(6, 8)}`;
+  return { date, allDay };
+};
+
+const parseICSEvents = (text) => {
+  const lines = unfoldLines(text);
+  const events = [];
+  let current = null;
+
+  lines.forEach(line => {
+    if (line === 'BEGIN:VEVENT') {
+      current = {};
+      return;
+    }
+
+    if (line === 'END:VEVENT') {
+      if (current) {
+        events.push(current);
+      }
+      current = null;
+      return;
+    }
+
+    if (!current) return;
+
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex === -1) return;
+
+    const property = line.slice(0, separatorIndex);
+    const value = line.slice(separatorIndex + 1);
+    const { key, params } = parseProperty(property);
+
+    current[key] = { value: value.trim(), params };
+  });
+
+  return events;
+};
+
+const normalizeStatus = (statusField) => {
+  if (!statusField || !statusField.value) {
+    return 'todo';
+  }
+
+  const normalized = statusField.value.toLowerCase();
+  const mapped = STATUS_MAP[normalized];
+  if (mapped) {
+    return mapped;
+  }
+
+  if (normalized.includes('progress')) {
+    return 'doing';
+  }
+
+  if (normalized.includes('complete')) {
+    return 'done';
+  }
+
+  return 'todo';
+};
+
+const resolveTopic = (categoriesField) => {
+  if (!categoriesField || !categoriesField.value) {
+    return undefined;
+  }
+
+  const categories = categoriesField.value
+    .split(',')
+    .map(cat => cat.trim())
+    .filter(Boolean);
+
+  if (categories.length === 0) {
+    return undefined;
+  }
+
+  const first = categories[0];
+  const existing = TaskModel.getTopics().find(topic => topic.toLowerCase() === first.toLowerCase());
+
+  if (existing) {
+    return existing;
+  }
+
+  const result = TaskModel.addTopic(first);
+  if (result && result.success) {
+    return result.topic;
+  }
+
+  return undefined;
+};
+
 export const ICSUtils = {
   exportICS() {
     const tasks = TaskModel.getTasks();
@@ -39,5 +190,49 @@ export const ICSUtils = {
     a.download = 'taskboard-export.ics';
     a.click();
     URL.revokeObjectURL(url);
+  },
+
+  async importICS(file) {
+    const text = await file.text();
+    const events = parseICSEvents(text);
+
+    if (events.length === 0) {
+      return { count: 0 };
+    }
+
+    const tasksToImport = events.reduce((acc, event) => {
+      const { date: startDate, allDay } = parseICSDate(event.DTSTART);
+      const endInfo = parseICSDate(event.DTEND);
+      const dueDate = endInfo.date || startDate;
+
+      if (!startDate && !dueDate) {
+        return acc;
+      }
+
+      const topic = resolveTopic(event.CATEGORIES);
+
+      acc.push({
+        title: decodeICSString(event.SUMMARY?.value || 'Evento importado'),
+        topic,
+        status: normalizeStatus(event.STATUS),
+        priority: 'medium',
+        startDate: startDate || dueDate,
+        dueDate,
+        allDay: allDay || endInfo.allDay,
+        repeat: null,
+        tags: [],
+        notes: decodeICSString(event.DESCRIPTION?.value || ''),
+        checklist: []
+      });
+
+      return acc;
+    }, []);
+
+    if (tasksToImport.length === 0) {
+      return { count: 0 };
+    }
+
+    const imported = TaskModel.importTasks(tasksToImport);
+    return { count: imported.length };
   }
 };

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -20,9 +20,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const modeToggleBtn = document.getElementById('toggle-mode');
   const importBtn = document.getElementById('import-json');
+  const importICSBtn = document.getElementById('import-ics');
   const exportBtn = document.getElementById('export-json');
   const exportICSBtn = document.getElementById('export-ics');
   const fileInput = document.getElementById('json-file');
+  const icsFileInput = document.getElementById('ics-file');
 
   const urlParams = new URLSearchParams(window.location.search);
   const mode = urlParams.get('mode') || 'local';
@@ -49,6 +51,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     fileInput.click();
   });
 
+  importICSBtn.addEventListener('click', () => {
+    icsFileInput.click();
+  });
+
   fileInput.addEventListener('change', async (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -65,6 +71,27 @@ document.addEventListener('DOMContentLoaded', async () => {
     } catch (err) {
       console.error(err);
       ToastView.show('Erro ao importar JSON.', 'danger');
+    }
+  });
+
+  icsFileInput.addEventListener('change', async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    try {
+      const { count } = await ICSUtils.importICS(file);
+
+      if (count > 0) {
+        ToastView.show(`${count} evento(s) importado(s) do ICS!`, 'success');
+        window.location.reload();
+      } else {
+        ToastView.show('Nenhum evento válido encontrado no arquivo ICS.', 'info');
+      }
+    } catch (err) {
+      console.error(err);
+      ToastView.show('Erro ao importar ICS.', 'danger');
+    } finally {
+      e.target.value = '';
     }
   });
 

--- a/index.html
+++ b/index.html
@@ -13,11 +13,13 @@
     <a class="navbar-brand" href="#">TaskBoard</a>
     <div class="ms-auto d-flex gap-2">
       <button id="import-json" class="btn btn-outline-light btn-sm">Importar JSON</button>
+      <button id="import-ics" class="btn btn-outline-light btn-sm">Importar ICS</button>
       <button id="export-json" class="btn btn-outline-light btn-sm">Exportar JSON</button>
       <button id="export-ics" class="btn btn-outline-light btn-sm">Exportar ICS</button>
       <button id="manage-topics" class="btn btn-outline-info btn-sm">Gerenciar Assuntos</button>
       <button id="toggle-mode" class="btn btn-outline-warning btn-sm">Modo: Local</button>
       <input type="file" id="json-file" accept=".json" hidden />
+      <input type="file" id="ics-file" accept=".ics,text/calendar" hidden />
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- add ICS import button and file input to the header toolbar
- parse VEVENT entries from .ics files and convert them into tasks, creating topics when needed
- support bulk importing of parsed tasks into the TaskModel with new helper method

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd313b0b9083259b9d262d729c2b56