### PR TITLE
Make calendar tasks open detail modal with status editing

### DIFF
--- a/assets/js/view/calendarView.js
+++ b/assets/js/view/calendarView.js
@@ -157,6 +157,8 @@ export const CalendarView = {
             const badge = document.createElement('span');
             const badgeClass = STATUS_BADGE[task.status] || 'text-bg-primary';
             badge.className = `badge ${badgeClass} d-block text-start text-wrap w-100`;
+            badge.setAttribute('role', 'button');
+            badge.tabIndex = 0;
             badge.textContent = this._formatTaskLabel(task);
             const periodLabel = this._formatTaskPeriod(task);
             if (periodLabel) {
@@ -164,6 +166,15 @@ export const CalendarView = {
             } else {
               badge.title = task.title;
             }
+            badge.addEventListener('click', () => {
+              EventBus.emit('openTaskDetail', task);
+            });
+            badge.addEventListener('keydown', event => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                EventBus.emit('openTaskDetail', task);
+              }
+            });
             list.appendChild(badge);
           });
 


### PR DESCRIPTION
## Summary
- make calendar task badges interactive so they open the detail modal via click or keyboard
- add a status selector to the task detail modal and refresh the badge when users change the status
- normalize task statuses when adding, updating, or loading tasks to keep data consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd361f1c2083259f0f4b2589dbedcf