### PR TITLE
feat: permitir atribuição de colaborador às tarefas

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -156,12 +156,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     ToastView.show(`Colaborador "${collaborator}" adicionado com sucesso!`, 'success');
   });
 
-  EventBus.on('collaboratorUpdated', ({ oldName, newName }) => {
-    const suffix = oldName !== newName ? ` Atualizado para "${newName}".` : '';
-    ToastView.show(`Colaborador editado.${suffix}`, 'info');
+  EventBus.on('collaboratorUpdated', ({ oldName, newName, updatedCount }) => {
+    let message = 'Colaborador editado.';
+    if (oldName !== newName) {
+      message += ` Atualizado para "${newName}".`;
+    }
+    if (updatedCount > 0) {
+      message += ` ${updatedCount} tarefa(s) atualizada(s).`;
+    }
+    ToastView.show(message, 'info');
   });
 
-  EventBus.on('collaboratorRemoved', (collaborator) => {
-    ToastView.show(`Colaborador "${collaborator}" removido.`, 'warning');
+  EventBus.on('collaboratorRemoved', ({ collaborator, clearedAssignments }) => {
+    let message = `Colaborador "${collaborator}" removido.`;
+    if (clearedAssignments > 0) {
+      message += ` ${clearedAssignments} tarefa(s) ficaram sem responsável.`;
+    }
+    ToastView.show(message, 'warning');
   });
 });

--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -69,6 +69,13 @@ export const ListView = {
         meta.appendChild(topicBadge);
         meta.appendChild(priorityBadge);
 
+        if (task.collaborator) {
+          const collaboratorBadge = document.createElement('span');
+          collaboratorBadge.className = 'badge bg-info text-dark';
+          collaboratorBadge.textContent = task.collaborator;
+          meta.appendChild(collaboratorBadge);
+        }
+
         body.appendChild(title);
         body.appendChild(date);
         body.appendChild(meta);

--- a/assets/js/view/modalView.js
+++ b/assets/js/view/modalView.js
@@ -26,6 +26,10 @@ export const ModalView = {
                 <select class="form-select" name="topic" required></select>
               </div>
               <div class="col-md-6">
+                <label class="form-label">Colaborador</label>
+                <select class="form-select" name="collaborator"></select>
+              </div>
+              <div class="col-md-6">
                 <label class="form-label">Data de Início</label>
                 <input type="date" class="form-control" name="startDate">
               </div>
@@ -61,6 +65,7 @@ export const ModalView = {
 
     document.body.insertAdjacentHTML('beforeend', modalHtml);
     this.updateTopicOptions();
+    this.updateCollaboratorOptions();
 
     this.form = document.getElementById('taskForm');
     const modalEl = document.getElementById('taskModal');
@@ -80,6 +85,7 @@ export const ModalView = {
           .map(tag => tag.trim())
           .filter(tag => tag.length > 0)
         : [];
+      data.collaborator = data.collaborator ? data.collaborator : null;
 
       if (this.currentTask) {
         const existingTask = TaskModel.getTaskById(this.currentTask.id);
@@ -108,9 +114,20 @@ export const ModalView = {
     select.innerHTML = options;
   },
 
+  updateCollaboratorOptions() {
+    const select = document.querySelector('#taskForm select[name="collaborator"]');
+    if (!select) return;
+    const collaborators = TaskModel.getCollaborators();
+    const options = [`<option value="">Sem colaborador</option>`]
+      .concat(collaborators.map(collaborator => `<option value="${collaborator}">${collaborator}</option>`))
+      .join('');
+    select.innerHTML = options;
+  },
+
   open(task = null) {
     this.currentTask = task ? { ...task } : null;
     this.updateTopicOptions();
+    this.updateCollaboratorOptions();
     this.form.reset();
 
     const title = document.getElementById('taskModalLabel');
@@ -131,6 +148,14 @@ export const ModalView = {
   fillForm(task) {
     this.form.querySelector('input[name="title"]').value = task.title || '';
     this.form.querySelector('select[name="topic"]').value = task.topic || '';
+    const collaboratorSelect = this.form.querySelector('select[name="collaborator"]');
+    if (collaboratorSelect) {
+      const options = Array.from(collaboratorSelect.options).map(option => option.value);
+      const value = task.collaborator && options.includes(task.collaborator)
+        ? task.collaborator
+        : '';
+      collaboratorSelect.value = value;
+    }
     this.form.querySelector('input[name="startDate"]').value = task.startDate || '';
     this.form.querySelector('input[name="dueDate"]').value = task.dueDate || '';
     this.form.querySelector('select[name="priority"]').value = task.priority || 'low';
@@ -151,4 +176,6 @@ EventBus.on('dataLoaded', () => ModalView.updateTopicOptions());
 EventBus.on('taskAdded', () => ModalView.updateTopicOptions());
 EventBus.on('taskUpdated', () => ModalView.updateTopicOptions());
 EventBus.on('topicsChanged', () => ModalView.updateTopicOptions());
+EventBus.on('dataLoaded', () => ModalView.updateCollaboratorOptions());
+EventBus.on('collaboratorsChanged', () => ModalView.updateCollaboratorOptions());
 EventBus.on('openTaskModal', (task) => ModalView.open(task));

--- a/assets/js/view/taskDetailView.js
+++ b/assets/js/view/taskDetailView.js
@@ -31,6 +31,10 @@ export const TaskDetailView = {
                   <h6 class="fw-bold">Assunto</h6>
                   <p class="mb-0" data-detail="topic"></p>
                 </div>
+                <div class="col-md-6">
+                  <h6 class="fw-bold">Colaborador</h6>
+                  <p class="mb-0" data-detail="collaborator"></p>
+                </div>
                 <div class="col-md-3">
                   <h6 class="fw-bold">Início</h6>
                   <p class="mb-0" data-detail="startDate"></p>
@@ -137,6 +141,7 @@ export const TaskDetailView = {
   fillDetails(task) {
     this.setText('title', task.title || '—');
     this.setText('topic', task.topic || '—');
+    this.setText('collaborator', task.collaborator || '—');
     this.setText('startDate', task.startDate || '—');
     this.setText('dueDate', task.dueDate || '—');
 


### PR DESCRIPTION
## Summary
- adiciona um campo de seleção de colaborador ao modal de criação e edição de tarefas
- passa a persistir o colaborador atribuído, exibindo-o nos detalhes e nos cards da lista
- garante a atualização das tarefas ao renomear ou remover colaboradores, com feedback apropriado

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd881f26ec8325a4815b2f7f71b23c