### PR TITLE
Add responsive header menu toggle

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -64,9 +64,21 @@ body {
 .app-header__actions {
   margin-left: auto;
   display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.app-header__actions-group {
+  display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 0.5rem;
+}
+
+.app-header__menu-toggle {
+  display: none;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .app-header__actions .btn {
@@ -99,11 +111,26 @@ body {
 @media (max-width: 992px) {
   .app-header__actions {
     width: 100%;
-    justify-content: flex-start;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .app-header__title {
     font-size: 1.25rem;
+  }
+
+  .app-header__menu-toggle {
+    display: inline-flex;
+  }
+
+  .app-header__actions-group {
+    width: 100%;
+    display: none;
+    justify-content: flex-start;
+  }
+
+  .app-header__actions-group.is-open {
+    display: flex;
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,6 +27,32 @@ document.addEventListener('DOMContentLoaded', async () => {
   const exportICSBtn = document.getElementById('export-ics');
   const fileInput = document.getElementById('json-file');
   const icsFileInput = document.getElementById('ics-file');
+  const headerMenuToggle = document.getElementById('header-menu-toggle');
+  const headerActionsGroup = document.querySelector('[data-header-actions]');
+
+  if (headerMenuToggle && headerActionsGroup) {
+    const closeMenu = () => {
+      headerActionsGroup.classList.remove('is-open');
+      headerMenuToggle.setAttribute('aria-expanded', 'false');
+    };
+
+    headerMenuToggle.addEventListener('click', () => {
+      const isOpen = headerActionsGroup.classList.toggle('is-open');
+      headerMenuToggle.setAttribute('aria-expanded', String(isOpen));
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!headerActionsGroup.contains(event.target) && !headerMenuToggle.contains(event.target)) {
+        closeMenu();
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth >= 992) {
+        closeMenu();
+      }
+    });
+  }
 
   const urlParams = new URLSearchParams(window.location.search);
   const mode = urlParams.get('mode') || 'local';

--- a/index.html
+++ b/index.html
@@ -16,15 +16,20 @@
         <img src="./assets/img/logo-mestra-anos.png" alt="25 anos Mestra Informática" class="brand-logo brand-logo--anniversary" />
       </div>
       <div class="app-header__actions">
-      <button id="import-json" class="btn btn-outline-light btn-sm">Importar JSON</button>
-      <button id="import-ics" class="btn btn-outline-light btn-sm">Importar ICS</button>
-      <button id="export-json" class="btn btn-outline-light btn-sm">Exportar JSON</button>
-      <button id="export-ics" class="btn btn-outline-light btn-sm">Exportar ICS</button>
-      <button id="manage-collaborators" class="btn btn-outline-success btn-sm">Gerenciar Colaboradores</button>
-      <button id="manage-topics" class="btn btn-outline-info btn-sm">Gerenciar Assuntos</button>
-      <button id="toggle-mode" class="btn btn-outline-warning btn-sm">Modo: Local</button>
-      <input type="file" id="json-file" accept=".json" hidden />
-      <input type="file" id="ics-file" accept=".ics,text/calendar" hidden />
+        <button id="header-menu-toggle" class="btn btn-outline-light btn-sm app-header__menu-toggle" type="button" aria-expanded="false" aria-controls="app-header-actions-group">
+          Menu
+        </button>
+        <div class="app-header__actions-group" id="app-header-actions-group" data-header-actions>
+          <button id="import-json" class="btn btn-outline-light btn-sm">Importar JSON</button>
+          <button id="import-ics" class="btn btn-outline-light btn-sm">Importar ICS</button>
+          <button id="export-json" class="btn btn-outline-light btn-sm">Exportar JSON</button>
+          <button id="export-ics" class="btn btn-outline-light btn-sm">Exportar ICS</button>
+          <button id="manage-collaborators" class="btn btn-outline-success btn-sm">Gerenciar Colaboradores</button>
+          <button id="manage-topics" class="btn btn-outline-info btn-sm">Gerenciar Assuntos</button>
+          <button id="toggle-mode" class="btn btn-outline-warning btn-sm">Modo: Local</button>
+          <input type="file" id="json-file" accept=".json" hidden />
+          <input type="file" id="ics-file" accept=".ics,text/calendar" hidden />
+        </div>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- group action buttons under a responsive header menu toggle
- add styles to show/hide the actions menu on smaller screens
- handle menu toggle behaviour with click, outside click, and resize listeners

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd9451b1cc8325a631973e2e9cf0a9