### PR TITLE
Add status management module with dynamic workflow statuses

### DIFF
--- a/assets/js/core/icsUtils.js
+++ b/assets/js/core/icsUtils.js
@@ -103,24 +103,24 @@ const parseICSEvents = (text) => {
 
 const normalizeStatus = (statusField) => {
   if (!statusField || !statusField.value) {
-    return 'todo';
+    return TaskModel.getDefaultStatusId();
   }
 
   const normalized = statusField.value.toLowerCase();
   const mapped = STATUS_MAP[normalized];
   if (mapped) {
-    return mapped;
+    return TaskModel.resolveStatusId(mapped);
   }
 
   if (normalized.includes('progress')) {
-    return 'doing';
+    return TaskModel.resolveStatusId('doing');
   }
 
   if (normalized.includes('complete')) {
-    return 'done';
+    return TaskModel.resolveStatusId('done');
   }
 
-  return 'todo';
+  return TaskModel.getDefaultStatusId();
 };
 
 const resolveTopic = (categoriesField) => {
@@ -177,7 +177,7 @@ export const ICSUtils = {
         'DESCRIPTION:' + (task.notes || ''),
         'DTSTART:' + dtstart,
         'DTEND:' + dtend,
-        'STATUS:' + (task.status === 'done' ? 'COMPLETED' : 'CONFIRMED'),
+        'STATUS:' + (TaskModel.resolveStatusId(task.status) === 'done' ? 'COMPLETED' : 'CONFIRMED'),
         'END:VEVENT'
       );
     });

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,6 +12,7 @@ import { ICSUtils } from './core/icsUtils.js';
 import { EventBus } from './core/eventBus.js';
 import { TopicManagerView } from './view/topicManagerView.js';
 import { CollaboratorManagerView } from './view/collaboratorManagerView.js';
+import { StatusManagerView } from './view/statusManagerView.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   ToastView.init();
@@ -19,6 +20,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   TaskDetailView.init();
   TopicManagerView.init();
   CollaboratorManagerView.init();
+  StatusManagerView.init();
 
   const modeToggleBtn = document.getElementById('toggle-mode');
   const importBtn = document.getElementById('import-json');
@@ -197,6 +199,26 @@ document.addEventListener('DOMContentLoaded', async () => {
     let message = `Colaborador "${collaborator}" removido.`;
     if (clearedAssignments > 0) {
       message += ` ${clearedAssignments} tarefa(s) ficaram sem responsável.`;
+    }
+    ToastView.show(message, 'warning');
+  });
+
+  EventBus.on('statusAdded', (status) => {
+    ToastView.show(`Status "${status.label}" criado com sucesso!`, 'success');
+  });
+
+  EventBus.on('statusUpdated', ({ oldLabel, newLabel }) => {
+    let message = 'Status atualizado.';
+    if (oldLabel !== newLabel) {
+      message += ` Novo nome: "${newLabel}".`;
+    }
+    ToastView.show(message, 'info');
+  });
+
+  EventBus.on('statusRemoved', ({ removed, fallback, reassignedCount }) => {
+    let message = `Status "${removed.label}" removido.`;
+    if (reassignedCount > 0 && fallback) {
+      message += ` ${reassignedCount} tarefa(s) movida(s) para "${fallback.label}".`;
     }
     ToastView.show(message, 'warning');
   });

--- a/assets/js/view/calendarView.js
+++ b/assets/js/view/calendarView.js
@@ -18,10 +18,13 @@ import { ptBR } from 'https://cdn.jsdelivr.net/npm/date-fns@3.6.0/locale/pt-BR/+
 
 const WEEK_DAYS = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
 
-const STATUS_BADGE = {
-  todo: 'text-bg-secondary',
-  doing: 'text-bg-info',
-  done: 'text-bg-success'
+const getStatusBadgeClass = (statusId) => {
+  const status = TaskModel.getStatusById(statusId);
+  if (status && status.badgeClass) {
+    return status.badgeClass;
+  }
+
+  return 'text-bg-primary';
 };
 
 export const CalendarView = {
@@ -155,7 +158,7 @@ export const CalendarView = {
 
           dayTasks.forEach(task => {
             const badge = document.createElement('span');
-            const badgeClass = STATUS_BADGE[task.status] || 'text-bg-primary';
+            const badgeClass = getStatusBadgeClass(task.status);
             badge.className = `badge ${badgeClass} d-block text-start text-wrap w-100`;
             badge.setAttribute('role', 'button');
             badge.tabIndex = 0;
@@ -265,5 +268,9 @@ EventBus.on('taskRemoved', () => {
 });
 
 EventBus.on('tasksBulkUpdated', () => {
+  CalendarView.render(CalendarView.currentMonth, CalendarView.currentTopic);
+});
+
+EventBus.on('statusesChanged', () => {
   CalendarView.render(CalendarView.currentMonth, CalendarView.currentTopic);
 });

--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -9,17 +9,24 @@ export const ListView = {
     const tasks = TaskModel.getTasks();
     const filtered = currentTopic === 'Todos' ? tasks : tasks.filter(t => t.topic === currentTopic);
 
-    const statusList = ['todo', 'doing', 'done'];
-    const statusLabels = {
-      'todo': 'A Fazer',
-      'doing': 'Em Progresso',
-      'done': 'Concluído'
-    };
+    const statuses = TaskModel.getStatuses();
 
     const row = document.createElement('div');
     row.className = 'row';
 
-    statusList.forEach(status => {
+    if (!Array.isArray(statuses) || statuses.length === 0) {
+      const emptyCol = document.createElement('div');
+      emptyCol.className = 'col-12';
+      const emptyBox = document.createElement('div');
+      emptyBox.className = 'alert alert-light border text-center';
+      emptyBox.textContent = 'Nenhum status disponível.';
+      emptyCol.appendChild(emptyBox);
+      row.appendChild(emptyCol);
+      content.appendChild(row);
+      return;
+    }
+
+    statuses.forEach(status => {
       const col = document.createElement('div');
       col.className = 'col-md-4 mb-3';
 
@@ -27,12 +34,12 @@ export const ListView = {
       box.className = 'border rounded bg-white shadow-sm p-2';
 
       const header = document.createElement('h6');
-      header.textContent = statusLabels[status];
+      header.textContent = status.label;
       header.className = 'text-primary border-bottom pb-1 mb-2';
 
       box.appendChild(header);
 
-      filtered.filter(t => t.status === status).forEach(task => {
+      filtered.filter(t => t.status === status.id).forEach(task => {
         const card = document.createElement('div');
 
         card.className = 'card mb-2 task-card';
@@ -125,6 +132,12 @@ EventBus.on('taskRemoved', () => {
 });
 
 EventBus.on('tasksBulkUpdated', () => {
+  const activeTab = document.querySelector('#tab-topics .nav-link.active');
+  const topic = activeTab?.dataset.topic || 'Todos';
+  ListView.render(topic);
+});
+
+EventBus.on('statusesChanged', () => {
   const activeTab = document.querySelector('#tab-topics .nav-link.active');
   const topic = activeTab?.dataset.topic || 'Todos';
   ListView.render(topic);

--- a/assets/js/view/statusManagerView.js
+++ b/assets/js/view/statusManagerView.js
@@ -1,0 +1,201 @@
+import { TaskModel } from '../model/taskModel.js';
+import { EventBus } from '../core/eventBus.js';
+import { ToastView } from './toastView.js';
+
+export const StatusManagerView = {
+  modal: null,
+  modalEl: null,
+  listEl: null,
+  formEl: null,
+  inputEl: null,
+
+  init() {
+    const manageButton = document.getElementById('manage-statuses');
+    if (!manageButton) return;
+
+    this._injectModal();
+
+    manageButton.addEventListener('click', () => {
+      this.open();
+    });
+
+    EventBus.on('dataLoaded', () => this.render());
+    EventBus.on('statusesChanged', () => this.render());
+  },
+
+  _injectModal() {
+    if (this.modalEl) return;
+
+    const modalHtml = `
+      <div class="modal fade" id="statusManagerModal" tabindex="-1" aria-labelledby="statusManagerLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="statusManagerLabel">Gerenciar Status</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+            </div>
+            <div class="modal-body">
+              <form id="statusManagerForm" class="row g-2">
+                <div class="col-12">
+                  <label class="form-label" for="statusManagerInput">Adicionar novo status</label>
+                  <div class="input-group">
+                    <input type="text" class="form-control" id="statusManagerInput" placeholder="ex: Em Revisão" required>
+                    <button class="btn btn-success" type="submit">Adicionar</button>
+                  </div>
+                </div>
+              </form>
+              <div class="mt-4">
+                <h6 class="fw-semibold">Status cadastrados</h6>
+                <div data-status-list class="list-group"></div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+
+    this.modalEl = document.getElementById('statusManagerModal');
+    this.modal = new bootstrap.Modal(this.modalEl);
+    this.listEl = this.modalEl.querySelector('[data-status-list]');
+    this.formEl = this.modalEl.querySelector('#statusManagerForm');
+    this.inputEl = this.modalEl.querySelector('#statusManagerInput');
+
+    this.modalEl.addEventListener('shown.bs.modal', () => {
+      this.inputEl?.focus();
+    });
+
+    this.formEl.addEventListener('submit', (event) => {
+      event.preventDefault();
+      this._handleAddStatus();
+    });
+  },
+
+  open() {
+    if (!this.modal) return;
+    this.render();
+    this.modal.show();
+  },
+
+  render() {
+    if (!this.listEl) return;
+
+    const statuses = TaskModel.getStatuses();
+    this.listEl.innerHTML = '';
+
+    if (!Array.isArray(statuses) || statuses.length === 0) {
+      const emptyItem = document.createElement('div');
+      emptyItem.className = 'list-group-item text-muted';
+      emptyItem.textContent = 'Nenhum status cadastrado.';
+      this.listEl.appendChild(emptyItem);
+      return;
+    }
+
+    const tasks = TaskModel.getTasks();
+
+    statuses.forEach(status => {
+      const item = document.createElement('div');
+      item.className = 'list-group-item d-flex justify-content-between align-items-center gap-2 flex-wrap';
+
+      const infoContainer = document.createElement('div');
+      infoContainer.className = 'd-flex align-items-center gap-2';
+
+      const badge = document.createElement('span');
+      badge.className = `badge ${status.badgeClass || 'text-bg-secondary'}`;
+      badge.textContent = status.label;
+
+      const code = document.createElement('span');
+      code.className = 'text-muted small';
+      code.textContent = `(${status.id})`;
+
+      const count = tasks.filter(task => task.status === status.id).length;
+      const countBadge = document.createElement('span');
+      countBadge.className = 'badge bg-light text-dark';
+      countBadge.textContent = `${count} tarefa${count === 1 ? '' : 's'}`;
+
+      infoContainer.appendChild(badge);
+      infoContainer.appendChild(code);
+      infoContainer.appendChild(countBadge);
+
+      const actions = document.createElement('div');
+      actions.className = 'btn-group btn-group-sm';
+
+      const renameBtn = document.createElement('button');
+      renameBtn.type = 'button';
+      renameBtn.className = 'btn btn-outline-secondary';
+      renameBtn.textContent = 'Renomear';
+      renameBtn.addEventListener('click', () => {
+        this._handleRenameStatus(status);
+      });
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'btn btn-outline-danger';
+      deleteBtn.textContent = 'Excluir';
+      deleteBtn.addEventListener('click', () => {
+        this._handleRemoveStatus(status);
+      });
+
+      actions.appendChild(renameBtn);
+      actions.appendChild(deleteBtn);
+
+      item.appendChild(infoContainer);
+      item.appendChild(actions);
+
+      this.listEl.appendChild(item);
+    });
+  },
+
+  _handleAddStatus() {
+    const value = this.inputEl?.value ?? '';
+    const result = TaskModel.addStatus(value);
+
+    if (!result.success) {
+      this._showError(result.reason);
+      return;
+    }
+
+    this.inputEl.value = '';
+  },
+
+  _handleRenameStatus(status) {
+    const newLabel = prompt('Informe o novo nome para o status:', status.label);
+    if (newLabel === null) {
+      return;
+    }
+
+    const result = TaskModel.updateStatus(status.id, newLabel);
+    if (!result.success) {
+      this._showError(result.reason);
+    }
+  },
+
+  _handleRemoveStatus(status) {
+    const confirmation = confirm(`Deseja realmente excluir o status "${status.label}"?`);
+    if (!confirmation) {
+      return;
+    }
+
+    const result = TaskModel.removeStatus(status.id);
+    if (!result.success) {
+      this._showError(result.reason);
+    }
+  },
+
+  _showError(reason) {
+    const messages = {
+      empty: 'Informe um nome válido para o status.',
+      duplicate: 'Já existe um status com esse nome.',
+      unchanged: 'O status já possui esse nome.',
+      notfound: 'Status não encontrado.',
+      minimum: 'Mantenha pelo menos um status cadastrado.'
+    };
+
+    const message = messages[reason] || 'Não foi possível completar a ação.';
+    ToastView.show(message, 'danger');
+  }
+};

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
           <button id="export-ics" class="btn btn-outline-light btn-sm">Exportar ICS</button>
           <button id="manage-collaborators" class="btn btn-outline-success btn-sm">Gerenciar Colaboradores</button>
           <button id="manage-topics" class="btn btn-outline-info btn-sm">Gerenciar Assuntos</button>
+          <button id="manage-statuses" class="btn btn-outline-primary btn-sm">Gerenciar Status</button>
           <button id="toggle-mode" class="btn btn-outline-warning btn-sm">Modo: Local</button>
           <input type="file" id="json-file" accept=".json" hidden />
           <input type="file" id="ics-file" accept=".ics,text/calendar" hidden />


### PR DESCRIPTION
## Summary
- add a status management modal and header action to create, editar e apagar status
- extend TaskModel and related views to use dynamic status definitions across board, detalhes e calendário
- ajustar importação/exportação ICS e feedbacks para refletir o novo fluxo de status

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda2cd11888325ae95409e5a1df7a1