### PR TITLE
Add task dependency support and searchable selection

### DIFF
--- a/assets/js/view/calendarView.js
+++ b/assets/js/view/calendarView.js
@@ -229,10 +229,15 @@ export const CalendarView = {
   },
 
   _formatTaskLabel(task) {
-    if (this.currentTopic === 'Todos' && task.topic) {
-      return `${task.topic} · ${task.title}`;
+    const baseLabel = this.currentTopic === 'Todos' && task.topic
+      ? `${task.topic} · ${task.title}`
+      : task.title;
+
+    if (Array.isArray(task.dependencies) && task.dependencies.length > 0) {
+      return `${baseLabel} ⛓`;
     }
-    return task.title;
+
+    return baseLabel;
   },
 
   _formatTaskPeriod(task) {

--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -83,6 +83,16 @@ export const ListView = {
           meta.appendChild(collaboratorBadge);
         }
 
+        if (Array.isArray(task.dependencies) && task.dependencies.length > 0) {
+          const dependencyBadge = document.createElement('span');
+          dependencyBadge.className = 'badge bg-light text-dark border';
+          const count = task.dependencies.length;
+          dependencyBadge.textContent = count === 1
+            ? '1 dependência'
+            : `${count} dependências`;
+          meta.appendChild(dependencyBadge);
+        }
+
         body.appendChild(title);
         body.appendChild(date);
         body.appendChild(meta);

--- a/assets/js/view/taskDetailView.js
+++ b/assets/js/view/taskDetailView.js
@@ -54,6 +54,10 @@ export const TaskDetailView = {
                 <div class="d-flex flex-wrap gap-2" data-detail="tags"></div>
               </div>
               <div class="mt-3">
+                <h6 class="fw-bold">Dependências</h6>
+                <div class="d-flex flex-column gap-2" data-detail="dependencies"></div>
+              </div>
+              <div class="mt-3">
                 <h6 class="fw-bold">Notas</h6>
                 <p class="mb-0" data-detail="notes"></p>
               </div>
@@ -133,6 +137,22 @@ export const TaskDetailView = {
       this._populateStatusSelect();
       this._updateStatusBadge(TaskModel.getDefaultStatusId());
     });
+
+    EventBus.on('tasksBulkUpdated', () => {
+      this._refreshCurrentTask();
+    });
+
+    EventBus.on('taskRemoved', (removedTask) => {
+      if (removedTask && this.currentTask?.id === removedTask.id) {
+        this.modal.hide();
+        return;
+      }
+      this._refreshCurrentTask();
+    });
+
+    EventBus.on('taskUpdated', () => {
+      this._refreshCurrentTask();
+    });
   },
 
   open(task) {
@@ -186,6 +206,7 @@ export const TaskDetailView = {
     }
 
     this.setText('notes', task.notes || 'Sem notas');
+    this._renderDependencies(task.dependencies);
   },
 
   clearDetails() {
@@ -252,5 +273,64 @@ export const TaskDetailView = {
     const defaultStatus = TaskModel.getDefaultStatusId();
     const statusToSelect = statuses.find(status => status.id === selectedId)?.id || defaultStatus;
     statusSelect.value = statusToSelect;
+  },
+
+  _renderDependencies(dependencyIds) {
+    const container = this.modalEl.querySelector('[data-detail="dependencies"]');
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = '';
+
+    if (!Array.isArray(dependencyIds) || dependencyIds.length === 0) {
+      const empty = document.createElement('span');
+      empty.className = 'text-muted';
+      empty.textContent = 'Sem dependências registradas';
+      container.appendChild(empty);
+      return;
+    }
+
+    dependencyIds.forEach(depId => {
+      const dependencyTask = TaskModel.getTaskById(depId);
+      const item = document.createElement('div');
+      item.className = 'd-flex flex-wrap align-items-center gap-2';
+
+      const titleBadge = document.createElement('span');
+      titleBadge.className = 'badge bg-light text-dark';
+      titleBadge.textContent = dependencyTask?.title || 'Atividade indisponível';
+      item.appendChild(titleBadge);
+
+      if (dependencyTask) {
+        const status = TaskModel.getStatusById(dependencyTask.status);
+        if (status) {
+          const statusBadge = document.createElement('span');
+          statusBadge.className = `badge ${status.badgeClass || 'text-bg-secondary'}`;
+          statusBadge.textContent = status.label;
+          item.appendChild(statusBadge);
+        }
+      } else {
+        const missing = document.createElement('span');
+        missing.className = 'text-muted small';
+        missing.textContent = 'Removida ou não encontrada';
+        item.appendChild(missing);
+      }
+
+      container.appendChild(item);
+    });
+  },
+
+  _refreshCurrentTask() {
+    if (!this.currentTask) {
+      return;
+    }
+
+    const latest = TaskModel.getTaskById(this.currentTask.id);
+    if (!latest) {
+      return;
+    }
+
+    this.currentTask = { ...latest };
+    this.fillDetails(this.currentTask);
   }
 };

--- a/tests/helpers/fakeDom.js
+++ b/tests/helpers/fakeDom.js
@@ -175,6 +175,12 @@ class FakeDocument {
       const matches = form.findDescendants(el => el.tagName === 'SELECT' && (el.name === 'topic' || el.getAttribute('name') === 'topic'));
       return matches[0] || null;
     }
+    if (selector === '#taskForm select[name="dependencies"]') {
+      const form = this.getElementById('taskForm');
+      if (!form) return null;
+      const matches = form.findDescendants(el => el.tagName === 'SELECT' && (el.name === 'dependencies' || el.getAttribute('name') === 'dependencies'));
+      return matches[0] || null;
+    }
     if (selector === '#tab-topics .nav-link.active') {
       const links = this.querySelectorAll('#tab-topics .nav-link');
       return links.find(link => link.classList.contains('active')) || null;


### PR DESCRIPTION
## Summary
- add dependency handling to tasks with normalization and persistence updates
- extend task creation and detail modals to manage and display dependencies with searchable selection UI
- surface dependency indicators in calendar/list views and add regression tests for dependency logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda9034d148325a3674c867c35684b