### PR TITLE
Revamp task detail modal UI and fix card interactions

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -272,12 +272,395 @@ body {
 
 .task-card {
   cursor: pointer;
+  border: none;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #ffffff 0%, #f3f6ff 100%);
+  box-shadow: 0 0.75rem 1.5rem rgba(16, 26, 84, 0.08);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.task-card .card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.task-card .card-title {
+  font-weight: 600;
+  color: #132a74;
+}
+
+.task-card small.text-muted {
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #475569 !important;
+}
+
+.task-card .badge {
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.3rem 0.65rem;
+}
+
+.task-card .badge.bg-secondary {
+  background-color: rgba(17, 25, 61, 0.08) !important;
+  color: #11193d !important;
+}
+
+.task-card .badge.bg-light {
+  background-color: rgba(15, 23, 42, 0.08) !important;
+  color: #0f172a !important;
 }
 
 .task-card:hover,
 .task-card:focus {
-  transform: translateY(-2px);
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  transform: translateY(-4px);
+  box-shadow: 0 1rem 2rem rgba(16, 26, 84, 0.18);
   outline: none;
+}
+
+.task-card:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.5);
+  outline-offset: 4px;
+}
+
+.task-detail-modal {
+  border: none;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: linear-gradient(180deg, #f9fafe 0%, #ffffff 100%);
+  box-shadow: 0 2rem 3.5rem rgba(12, 21, 56, 0.25);
+}
+
+.task-detail-modal__hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1.5rem;
+  padding: 2.25rem 2.5rem 1.75rem;
+  background: linear-gradient(135deg, #050b2c 0%, #162a72 58%, #2f48a1 100%);
+  color: #f8faff;
+}
+
+.task-detail-modal__hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 45%);
+  pointer-events: none;
+}
+
+.task-detail-modal__hero-main,
+.task-detail-modal__hero-side {
+  position: relative;
+  z-index: 1;
+}
+
+.task-detail-modal__hero-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.task-detail-modal__title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.task-detail-modal__topic {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.15);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.task-detail-modal__topic--empty {
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(248, 250, 255, 0.75);
+}
+
+.task-detail-modal__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+}
+
+.task-detail-modal__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: rgba(248, 250, 255, 0.85);
+}
+
+.task-detail-modal__meta-item i {
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.task-detail-modal__hero-side {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+  min-width: 220px;
+}
+
+.task-detail-modal__status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.task-detail-modal__status .form-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 250, 255, 0.7);
+}
+
+.task-detail-modal__status .form-select {
+  border-radius: 0.75rem;
+  border: none;
+  padding: 0.45rem 0.9rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: #101a54;
+  box-shadow: none;
+}
+
+.task-detail-modal__status .form-select:focus {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
+}
+
+.task-detail-modal__status-badge {
+  margin-top: 0.75rem;
+  align-self: flex-start;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.task-detail-modal__priority {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.28);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.task-detail-modal__priority-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 255, 0.75);
+}
+
+.task-detail-modal__priority .badge {
+  font-size: 0.95rem;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+}
+
+.task-detail-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.task-detail-modal__body {
+  padding: 2rem 2.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.task-detail-modal__section {
+  background: #f8faff;
+  border: 1px solid #e4e9fb;
+  border-radius: 1.25rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.06);
+}
+
+.task-detail-modal__section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 700;
+  color: #162054;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 1rem;
+}
+
+.task-detail-modal__section-title i {
+  font-size: 1rem;
+  color: #2f48a1;
+}
+
+.task-detail-modal__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.task-detail-modal__tag {
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+}
+
+.task-detail-modal__dependencies {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-detail-modal__dependency {
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 0.5rem 1.25rem rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.task-detail-modal__dependency-title {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.task-detail-modal__dependency-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.task-detail-modal__dependency-topic {
+  background: rgba(47, 72, 161, 0.12);
+  color: #2f48a1;
+}
+
+.task-detail-modal__dependency small {
+  font-size: 0.75rem;
+}
+
+.task-detail-modal__dependency--missing {
+  border-style: dashed;
+  border-color: #f59e0b;
+}
+
+.task-detail-modal__empty {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.task-detail-modal__notes {
+  margin: 0;
+  line-height: 1.6;
+  color: #1f2937;
+  white-space: pre-wrap;
+}
+
+.task-detail-modal__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.75rem 2.5rem 2rem;
+  border-top: 1px solid #e7ecff;
+  background: #ffffff;
+}
+
+.task-detail-modal__footer .btn {
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.65rem 1.4rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
+}
+
+.task-detail-modal__actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.task-detail-modal__action {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.task-detail-modal__action:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.5);
+  border-radius: 50%;
+}
+
+.task-detail-modal__action-icon {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 0.2rem;
+  color: #ffffff;
+  font-weight: 700;
+  box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-detail-modal__action-icon i {
+  font-size: 1.1rem;
+}
+
+.task-detail-modal__action-icon small {
+  font-size: 0.55rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.task-detail-modal__action--edit .task-detail-modal__action-icon {
+  background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+}
+
+.task-detail-modal__action--delete .task-detail-modal__action-icon {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+}
+
+.task-detail-modal__action:hover .task-detail-modal__action-icon,
+.task-detail-modal__action:focus .task-detail-modal__action-icon {
+  transform: translateY(-4px);
+  box-shadow: 0 1.25rem 2.5rem rgba(15, 23, 42, 0.25);
+}
+
+@media (max-width: 991.98px) {
+  .task-detail-modal__hero {
+    grid-template-columns: 1fr;
+  }
+
+  .task-detail-modal__hero-side {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .task-detail-modal__footer {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .task-detail-modal__actions {
+    justify-content: center;
+  }
 }

--- a/assets/js/view/taskDetailView.js
+++ b/assets/js/view/taskDetailView.js
@@ -5,68 +5,86 @@ export const TaskDetailView = {
   modal: null,
   modalEl: null,
   currentTask: null,
+  tooltips: [],
 
   init() {
     const modalHtml = `
       <div class="modal fade" id="taskDetailModal" tabindex="-1" aria-labelledby="taskDetailModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="taskDetailModalLabel">Detalhes da Tarefa</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
-            </div>
-            <div class="modal-body">
-              <div class="mb-3">
-                <h6 class="fw-bold">Título</h6>
-                <p class="mb-0" data-detail="title"></p>
-              </div>
-              <div class="row g-3">
-                <div class="col-md-6">
-                  <h6 class="fw-bold">Assunto</h6>
-                  <p class="mb-0" data-detail="topic"></p>
-                </div>
-                <div class="col-md-6">
-                  <h6 class="fw-bold">Colaborador</h6>
-                  <p class="mb-0" data-detail="collaborator"></p>
-                </div>
-                <div class="col-md-3">
-                  <h6 class="fw-bold">Início</h6>
-                  <p class="mb-0" data-detail="startDate"></p>
-                </div>
-                <div class="col-md-3">
-                  <h6 class="fw-bold">Fim</h6>
-                  <p class="mb-0" data-detail="dueDate"></p>
+          <div class="modal-content task-detail-modal">
+            <div class="task-detail-modal__hero">
+              <div class="task-detail-modal__hero-main">
+                <span class="task-detail-modal__topic" data-detail="topic"></span>
+                <h2 class="task-detail-modal__title" id="taskDetailModalLabel" data-detail="title"></h2>
+                <div class="task-detail-modal__meta">
+                  <div class="task-detail-modal__meta-item">
+                    <i class="fa-solid fa-user" aria-hidden="true"></i>
+                    <span data-detail="collaborator"></span>
+                  </div>
+                  <div class="task-detail-modal__meta-item">
+                    <i class="fa-solid fa-calendar-day" aria-hidden="true"></i>
+                    <span>Início: <strong data-detail="startDate"></strong></span>
+                  </div>
+                  <div class="task-detail-modal__meta-item">
+                    <i class="fa-solid fa-calendar-check" aria-hidden="true"></i>
+                    <span>Fim: <strong data-detail="dueDate"></strong></span>
+                  </div>
                 </div>
               </div>
-              <div class="mt-3 row g-3 align-items-end">
-                <div class="col-md-6">
-                  <h6 class="fw-bold mb-1">Status</h6>
-                  <select class="form-select" data-detail="statusSelect"></select>
-                  <small class="d-block mt-2 text-muted">Atual: <span class="badge" data-detail="statusBadge"></span></small>
+              <div class="task-detail-modal__hero-side">
+                <div class="task-detail-modal__status">
+                  <label for="taskDetailStatusSelect" class="form-label">Status</label>
+                  <select class="form-select form-select-sm" id="taskDetailStatusSelect" data-detail="statusSelect"></select>
+                  <span class="badge task-detail-modal__status-badge" data-detail="statusBadge"></span>
                 </div>
-                <div class="col-md-6">
-                  <h6 class="fw-bold mb-1">Prioridade</h6>
+                <div class="task-detail-modal__priority">
+                  <span class="task-detail-modal__priority-label">Prioridade</span>
                   <span class="badge" data-detail="priority"></span>
                 </div>
               </div>
-              <div class="mt-3">
-                <h6 class="fw-bold">Tags</h6>
-                <div class="d-flex flex-wrap gap-2" data-detail="tags"></div>
-              </div>
-              <div class="mt-3">
-                <h6 class="fw-bold">Dependências</h6>
-                <div class="d-flex flex-column gap-2" data-detail="dependencies"></div>
-              </div>
-              <div class="mt-3">
-                <h6 class="fw-bold">Notas</h6>
-                <p class="mb-0" data-detail="notes"></p>
-              </div>
+              <button type="button" class="btn-close btn-close-white task-detail-modal__close" data-bs-dismiss="modal" aria-label="Fechar"></button>
             </div>
-            <div class="modal-footer d-flex justify-content-between">
-              <button type="button" class="btn btn-outline-danger" data-action="delete">Excluir</button>
-              <div class="d-flex gap-2">
-                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Fechar</button>
-                <button type="button" class="btn btn-primary" data-action="edit">Editar</button>
+            <div class="task-detail-modal__body">
+              <section class="task-detail-modal__section">
+                <h6 class="task-detail-modal__section-title">
+                  <i class="fa-solid fa-tags" aria-hidden="true"></i>
+                  Tags
+                </h6>
+                <div class="task-detail-modal__tags" data-detail="tags"></div>
+              </section>
+              <section class="task-detail-modal__section">
+                <h6 class="task-detail-modal__section-title">
+                  <i class="fa-solid fa-link" aria-hidden="true"></i>
+                  Dependências
+                </h6>
+                <div class="task-detail-modal__dependencies" data-detail="dependencies"></div>
+              </section>
+              <section class="task-detail-modal__section">
+                <h6 class="task-detail-modal__section-title">
+                  <i class="fa-regular fa-note-sticky" aria-hidden="true"></i>
+                  Notas
+                </h6>
+                <p class="task-detail-modal__notes" data-detail="notes"></p>
+              </section>
+            </div>
+            <div class="task-detail-modal__footer">
+              <button type="button" class="btn btn-light" data-bs-dismiss="modal">
+                <i class="fa-solid fa-arrow-left me-2" aria-hidden="true"></i>
+                Fechar
+              </button>
+              <div class="task-detail-modal__actions">
+                <button type="button" class="task-detail-modal__action task-detail-modal__action--edit" data-action="edit" data-bs-toggle="tooltip" data-bs-placement="top" title="Editar tarefa" aria-label="Editar tarefa">
+                  <span class="task-detail-modal__action-icon">
+                    <i class="fa-solid fa-pen" aria-hidden="true"></i>
+                    <small>Editar</small>
+                  </span>
+                </button>
+                <button type="button" class="task-detail-modal__action task-detail-modal__action--delete" data-action="delete" data-bs-toggle="tooltip" data-bs-placement="top" title="Excluir tarefa" aria-label="Excluir tarefa">
+                  <span class="task-detail-modal__action-icon">
+                    <i class="fa-solid fa-trash" aria-hidden="true"></i>
+                    <small>Excluir</small>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
@@ -77,6 +95,8 @@ export const TaskDetailView = {
     document.body.insertAdjacentHTML('beforeend', modalHtml);
     this.modalEl = document.getElementById('taskDetailModal');
     this.modal = new bootstrap.Modal(this.modalEl);
+
+    this._initActionTooltips();
 
     const statusSelect = this.modalEl.querySelector('[data-detail="statusSelect"]');
     this._populateStatusSelect();
@@ -120,6 +140,7 @@ export const TaskDetailView = {
     this.modalEl.addEventListener('hidden.bs.modal', () => {
       this.currentTask = null;
       this.clearDetails();
+      this.tooltips.forEach(tooltip => tooltip.hide());
     });
 
     EventBus.on('openTaskDetail', task => this.open(task));
@@ -137,7 +158,6 @@ export const TaskDetailView = {
       this._populateStatusSelect();
       this._updateStatusBadge(TaskModel.getDefaultStatusId());
     });
-
   },
 
   open(task) {
@@ -150,11 +170,18 @@ export const TaskDetailView = {
   },
 
   fillDetails(task) {
+    const topicText = task.topic || 'Sem assunto';
     this.setText('title', task.title || '—');
-    this.setText('topic', task.topic || '—');
-    this.setText('collaborator', task.collaborator || '—');
-    this.setText('startDate', task.startDate || '—');
-    this.setText('dueDate', task.dueDate || '—');
+    this.setText('topic', topicText);
+    this.setText('collaborator', task.collaborator || 'Sem colaborador');
+    this.setText('startDate', this._formatDate(task.startDate));
+    this.setText('dueDate', this._formatDate(task.dueDate));
+
+    const topicEl = this.modalEl.querySelector('[data-detail="topic"]');
+    topicEl?.classList.toggle('task-detail-modal__topic--empty', !task.topic);
+
+    const collaboratorEl = this.modalEl.querySelector('[data-detail="collaborator"]');
+    collaboratorEl?.classList.toggle('text-muted', !task.collaborator);
 
     const resolvedStatus = TaskModel.resolveStatusId(task.status);
     this._populateStatusSelect(resolvedStatus);
@@ -168,9 +195,9 @@ export const TaskDetailView = {
     const priorityLabels = {
       high: { text: 'Alta', className: 'bg-danger' },
       medium: { text: 'Média', className: 'bg-warning text-dark' },
-      low: { text: 'Baixa', className: 'bg-secondary' }
+      low: { text: 'Baixa', className: 'bg-success-subtle text-success-emphasis' }
     };
-    const priorityInfo = priorityLabels[task.priority] || { text: task.priority || '—', className: 'bg-light text-dark' };
+    const priorityInfo = priorityLabels[task.priority] || { text: task.priority || '—', className: 'bg-secondary' };
     priorityEl.className = `badge ${priorityInfo.className}`;
     priorityEl.textContent = priorityInfo.text;
 
@@ -179,18 +206,27 @@ export const TaskDetailView = {
     if (Array.isArray(task.tags) && task.tags.length > 0) {
       task.tags.forEach(tag => {
         const span = document.createElement('span');
-        span.className = 'badge bg-light text-dark';
+        span.className = 'badge rounded-pill task-detail-modal__tag';
         span.textContent = tag;
         tagsContainer.appendChild(span);
       });
     } else {
       const span = document.createElement('span');
-      span.className = 'text-muted';
-      span.textContent = 'Sem tags';
+      span.className = 'task-detail-modal__empty';
+      span.textContent = 'Sem tags cadastradas.';
       tagsContainer.appendChild(span);
     }
 
-    this.setText('notes', task.notes || 'Sem notas');
+    const notesEl = this.modalEl.querySelector('[data-detail="notes"]');
+    const trimmedNotes = (task.notes || '').trim();
+    if (trimmedNotes) {
+      notesEl.textContent = trimmedNotes;
+      notesEl.classList.remove('text-muted');
+    } else {
+      notesEl.textContent = 'Sem notas adicionais.';
+      notesEl.classList.add('text-muted');
+    }
+
     this._renderDependencies(task.dependencies);
   },
 
@@ -205,10 +241,21 @@ export const TaskDetailView = {
         el.textContent = '';
       }
     });
+
+    const topicEl = this.modalEl.querySelector('[data-detail="topic"]');
+    topicEl?.classList.remove('task-detail-modal__topic--empty');
+
+    const collaboratorEl = this.modalEl.querySelector('[data-detail="collaborator"]');
+    collaboratorEl?.classList.remove('text-muted');
+
+    const notesEl = this.modalEl.querySelector('[data-detail="notes"]');
+    notesEl?.classList.remove('text-muted');
+
     const priorityEl = this.modalEl.querySelector('[data-detail="priority"]');
     if (priorityEl) {
       priorityEl.className = 'badge';
     }
+
     const statusSelect = this.modalEl.querySelector('[data-detail="statusSelect"]');
     const defaultStatus = TaskModel.getDefaultStatusId();
     if (statusSelect) {
@@ -235,7 +282,7 @@ export const TaskDetailView = {
     const label = status?.label || 'A Fazer';
     const badgeClass = status?.badgeClass || 'bg-secondary';
 
-    statusBadge.className = `badge ${badgeClass}`;
+    statusBadge.className = `badge task-detail-modal__status-badge ${badgeClass}`;
     statusBadge.textContent = label;
   },
 
@@ -258,5 +305,104 @@ export const TaskDetailView = {
     const defaultStatus = TaskModel.getDefaultStatusId();
     const statusToSelect = statuses.find(status => status.id === selectedId)?.id || defaultStatus;
     statusSelect.value = statusToSelect;
+  },
+
+  _renderDependencies(dependencies) {
+    const container = this.modalEl.querySelector('[data-detail="dependencies"]');
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = '';
+
+    if (!Array.isArray(dependencies) || dependencies.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'task-detail-modal__empty';
+      empty.textContent = 'Sem dependências vinculadas.';
+      container.appendChild(empty);
+      return;
+    }
+
+    dependencies.forEach(dependencyId => {
+      const dependency = TaskModel.getTaskById(dependencyId);
+      const item = document.createElement('div');
+      item.className = 'task-detail-modal__dependency';
+
+      const title = document.createElement('span');
+      title.className = 'task-detail-modal__dependency-title';
+      title.textContent = dependency?.title || 'Atividade removida';
+      item.appendChild(title);
+
+      const meta = document.createElement('div');
+      meta.className = 'task-detail-modal__dependency-meta';
+
+      if (dependency) {
+        if (dependency.topic) {
+          const topic = document.createElement('span');
+          topic.className = 'badge task-detail-modal__dependency-topic';
+          topic.textContent = dependency.topic;
+          meta.appendChild(topic);
+        }
+
+        const statusId = TaskModel.resolveStatusId(dependency.status);
+        const status = TaskModel.getStatusById(statusId);
+        const statusBadge = document.createElement('span');
+        statusBadge.className = `badge ${status?.badgeClass || 'bg-secondary'}`;
+        statusBadge.textContent = status?.label || 'A Fazer';
+        meta.appendChild(statusBadge);
+
+        const start = this._formatDate(dependency.startDate);
+        const end = this._formatDate(dependency.dueDate);
+        if (start !== '—' || end !== '—') {
+          const dates = document.createElement('small');
+          dates.className = 'text-muted';
+          if (start === end) {
+            dates.textContent = `Prazo: ${end}`;
+          } else {
+            const startLabel = start !== '—' ? `Início ${start}` : '';
+            const endLabel = end !== '—' ? `Fim ${end}` : '';
+            dates.textContent = [startLabel, endLabel].filter(Boolean).join(' · ');
+          }
+          meta.appendChild(dates);
+        }
+      } else {
+        item.classList.add('task-detail-modal__dependency--missing');
+        const missing = document.createElement('small');
+        missing.className = 'text-muted';
+        missing.textContent = 'Atividade original não encontrada.';
+        meta.appendChild(missing);
+      }
+
+      item.appendChild(meta);
+      container.appendChild(item);
+    });
+  },
+
+  _initActionTooltips() {
+    this.tooltips.forEach(tooltip => tooltip.dispose());
+    this.tooltips = [];
+
+    const actionButtons = this.modalEl?.querySelectorAll('[data-bs-toggle="tooltip"]') || [];
+    actionButtons.forEach(button => {
+      const instance = new bootstrap.Tooltip(button);
+      this.tooltips.push(instance);
+    });
+  },
+
+  _formatDate(dateString) {
+    if (!dateString) {
+      return '—';
+    }
+
+    const parsed = new Date(dateString);
+    if (Number.isNaN(parsed.getTime())) {
+      return dateString;
+    }
+
+    return new Intl.DateTimeFormat('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    }).format(parsed);
   }
 };


### PR DESCRIPTION
## Summary
- redesign the task detail modal with a hero header, structured sections, and circular action buttons that include inline labels and tooltips
- restore dependency rendering logic and format task metadata to keep the detail modal functional and informative when opening cards
- refresh task card styling so the board looks modern and interactive, with updated hover and focus affordances

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc70619c08325b3f59ef2a1aa642a