### PR TITLE
Enable mobile scrolling and unify action buttons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -595,6 +595,15 @@ body {
   gap: 1rem;
 }
 
+.app-circle-action-group {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.app-circle-action,
 .task-detail-modal__action {
   background: transparent;
   border: none;
@@ -602,11 +611,13 @@ body {
   cursor: pointer;
 }
 
+.app-circle-action:focus-visible,
 .task-detail-modal__action:focus-visible {
   outline: 3px solid rgba(59, 130, 246, 0.5);
   border-radius: 50%;
 }
 
+.app-circle-action__icon,
 .task-detail-modal__action-icon {
   width: 3.25rem;
   height: 3.25rem;
@@ -622,24 +633,30 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.app-circle-action__icon i,
 .task-detail-modal__action-icon i {
   font-size: 1.1rem;
 }
 
+.app-circle-action__icon small,
 .task-detail-modal__action-icon small {
   font-size: 0.55rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
+.app-circle-action--edit .app-circle-action__icon,
 .task-detail-modal__action--edit .task-detail-modal__action-icon {
   background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
 }
 
+.app-circle-action--delete .app-circle-action__icon,
 .task-detail-modal__action--delete .task-detail-modal__action-icon {
   background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
 }
 
+.app-circle-action:hover .app-circle-action__icon,
+.app-circle-action:focus .app-circle-action__icon,
 .task-detail-modal__action:hover .task-detail-modal__action-icon,
 .task-detail-modal__action:focus .task-detail-modal__action-icon {
   transform: translateY(-4px);
@@ -662,5 +679,45 @@ body {
 
   .task-detail-modal__actions {
     justify-content: center;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .task-detail-modal {
+    max-height: calc(100vh - 1rem);
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .task-detail-modal__hero,
+  .task-detail-modal__body,
+  .task-detail-modal__footer {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .task-detail-modal__hero {
+    padding-top: 1.75rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .task-detail-modal__body {
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+  }
+
+  .task-detail-modal__footer {
+    padding-bottom: 1.75rem;
+  }
+
+  .app-circle-action-group {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .app-circle-action__icon,
+  .task-detail-modal__action-icon {
+    width: 3rem;
+    height: 3rem;
   }
 }

--- a/assets/js/view/collaboratorManagerView.js
+++ b/assets/js/view/collaboratorManagerView.js
@@ -112,19 +112,24 @@ export const CollaboratorManagerView = {
 
     collaborators.forEach(collaborator => {
       const item = document.createElement('div');
-      item.className = 'list-group-item d-flex justify-content-between align-items-center';
+      item.className = 'list-group-item d-flex justify-content-between align-items-center gap-3 flex-wrap';
 
       const title = document.createElement('span');
       title.textContent = collaborator;
-      title.className = 'me-3';
+      title.className = 'me-3 flex-grow-1';
 
       const actions = document.createElement('div');
-      actions.className = 'btn-group btn-group-sm';
+      actions.className = 'app-circle-action-group flex-shrink-0';
 
       const editBtn = document.createElement('button');
       editBtn.type = 'button';
-      editBtn.className = 'btn btn-outline-secondary';
-      editBtn.innerHTML = '<i class="fa-solid fa-pen"></i><span class="visually-hidden">Renomear</span>';
+      editBtn.className = 'app-circle-action app-circle-action--edit';
+      editBtn.innerHTML = `
+        <span class="app-circle-action__icon" aria-hidden="true">
+          <i class="fa-solid fa-pen"></i>
+          <small>Editar</small>
+        </span>
+      `.trim();
       editBtn.setAttribute('aria-label', 'Renomear colaborador');
       editBtn.title = 'Renomear';
       editBtn.addEventListener('click', () => {
@@ -133,8 +138,13 @@ export const CollaboratorManagerView = {
 
       const deleteBtn = document.createElement('button');
       deleteBtn.type = 'button';
-      deleteBtn.className = 'btn btn-outline-danger';
-      deleteBtn.innerHTML = '<i class="fa-solid fa-trash"></i><span class="visually-hidden">Excluir</span>';
+      deleteBtn.className = 'app-circle-action app-circle-action--delete';
+      deleteBtn.innerHTML = `
+        <span class="app-circle-action__icon" aria-hidden="true">
+          <i class="fa-solid fa-trash"></i>
+          <small>Excluir</small>
+        </span>
+      `.trim();
       deleteBtn.setAttribute('aria-label', 'Excluir colaborador');
       deleteBtn.title = 'Excluir';
       deleteBtn.addEventListener('click', () => {

--- a/assets/js/view/statusManagerView.js
+++ b/assets/js/view/statusManagerView.js
@@ -136,7 +136,7 @@ export const StatusManagerView = {
       this._setItemDragBehavior(item);
 
       const infoContainer = document.createElement('div');
-      infoContainer.className = 'd-flex align-items-center gap-2 flex-wrap';
+      infoContainer.className = 'd-flex align-items-center gap-2 flex-wrap flex-grow-1';
 
       const dragHandle = document.createElement('span');
       dragHandle.className = 'text-muted small user-select-none';
@@ -170,13 +170,18 @@ export const StatusManagerView = {
       infoContainer.appendChild(countBadge);
 
       const actions = document.createElement('div');
-      actions.className = 'btn-group btn-group-sm';
+      actions.className = 'app-circle-action-group flex-shrink-0';
 
       const renameBtn = document.createElement('button');
       renameBtn.type = 'button';
-      renameBtn.className = 'btn btn-outline-secondary';
+      renameBtn.className = 'app-circle-action app-circle-action--edit';
 
-      renameBtn.innerHTML = '<i class="fa-solid fa-pen"></i><span class="visually-hidden">Renomear</span>';
+      renameBtn.innerHTML = `
+        <span class="app-circle-action__icon" aria-hidden="true">
+          <i class="fa-solid fa-pen"></i>
+          <small>Editar</small>
+        </span>
+      `.trim();
       renameBtn.setAttribute('aria-label', 'Renomear status');
       renameBtn.title = 'Renomear';
       renameBtn.draggable = false;
@@ -187,8 +192,13 @@ export const StatusManagerView = {
 
       const deleteBtn = document.createElement('button');
       deleteBtn.type = 'button';
-      deleteBtn.className = 'btn btn-outline-danger';
-      deleteBtn.innerHTML = '<i class="fa-solid fa-trash"></i><span class="visually-hidden">Excluir</span>';
+      deleteBtn.className = 'app-circle-action app-circle-action--delete';
+      deleteBtn.innerHTML = `
+        <span class="app-circle-action__icon" aria-hidden="true">
+          <i class="fa-solid fa-trash"></i>
+          <small>Excluir</small>
+        </span>
+      `.trim();
       deleteBtn.setAttribute('aria-label', 'Excluir status');
       deleteBtn.title = 'Excluir';
 

--- a/assets/js/view/taskDetailView.js
+++ b/assets/js/view/taskDetailView.js
@@ -72,15 +72,15 @@ export const TaskDetailView = {
                 <i class="fa-solid fa-arrow-left me-2" aria-hidden="true"></i>
                 Fechar
               </button>
-              <div class="task-detail-modal__actions">
-                <button type="button" class="task-detail-modal__action task-detail-modal__action--edit" data-action="edit" data-bs-toggle="tooltip" data-bs-placement="top" title="Editar tarefa" aria-label="Editar tarefa">
-                  <span class="task-detail-modal__action-icon">
+              <div class="task-detail-modal__actions app-circle-action-group">
+                <button type="button" class="task-detail-modal__action task-detail-modal__action--edit app-circle-action app-circle-action--edit" data-action="edit" data-bs-toggle="tooltip" data-bs-placement="top" title="Editar tarefa" aria-label="Editar tarefa">
+                  <span class="task-detail-modal__action-icon app-circle-action__icon">
                     <i class="fa-solid fa-pen" aria-hidden="true"></i>
                     <small>Editar</small>
                   </span>
                 </button>
-                <button type="button" class="task-detail-modal__action task-detail-modal__action--delete" data-action="delete" data-bs-toggle="tooltip" data-bs-placement="top" title="Excluir tarefa" aria-label="Excluir tarefa">
-                  <span class="task-detail-modal__action-icon">
+                <button type="button" class="task-detail-modal__action task-detail-modal__action--delete app-circle-action app-circle-action--delete" data-action="delete" data-bs-toggle="tooltip" data-bs-placement="top" title="Excluir tarefa" aria-label="Excluir tarefa">
+                  <span class="task-detail-modal__action-icon app-circle-action__icon">
                     <i class="fa-solid fa-trash" aria-hidden="true"></i>
                     <small>Excluir</small>
                   </span>

--- a/assets/js/view/topicManagerView.js
+++ b/assets/js/view/topicManagerView.js
@@ -112,19 +112,24 @@ export const TopicManagerView = {
 
     topics.forEach(topic => {
       const item = document.createElement('div');
-      item.className = 'list-group-item d-flex justify-content-between align-items-center';
+      item.className = 'list-group-item d-flex justify-content-between align-items-center gap-3 flex-wrap';
 
       const title = document.createElement('span');
       title.textContent = topic;
-      title.className = 'me-3';
+      title.className = 'me-3 flex-grow-1';
 
       const actions = document.createElement('div');
-      actions.className = 'btn-group btn-group-sm';
+      actions.className = 'app-circle-action-group flex-shrink-0';
 
       const editBtn = document.createElement('button');
       editBtn.type = 'button';
-      editBtn.className = 'btn btn-outline-secondary';
-      editBtn.innerHTML = '<i class="fa-solid fa-pen"></i><span class="visually-hidden">Renomear</span>';
+      editBtn.className = 'app-circle-action app-circle-action--edit';
+      editBtn.innerHTML = `
+        <span class="app-circle-action__icon" aria-hidden="true">
+          <i class="fa-solid fa-pen"></i>
+          <small>Editar</small>
+        </span>
+      `.trim();
       editBtn.setAttribute('aria-label', 'Renomear assunto');
       editBtn.title = 'Renomear';
       editBtn.addEventListener('click', () => {
@@ -133,8 +138,13 @@ export const TopicManagerView = {
 
       const deleteBtn = document.createElement('button');
       deleteBtn.type = 'button';
-      deleteBtn.className = 'btn btn-outline-danger';
-      deleteBtn.innerHTML = '<i class="fa-solid fa-trash"></i><span class="visually-hidden">Excluir</span>';
+      deleteBtn.className = 'app-circle-action app-circle-action--delete';
+      deleteBtn.innerHTML = `
+        <span class="app-circle-action__icon" aria-hidden="true">
+          <i class="fa-solid fa-trash"></i>
+          <small>Excluir</small>
+        </span>
+      `.trim();
       deleteBtn.setAttribute('aria-label', 'Excluir assunto');
       deleteBtn.title = 'Excluir';
       deleteBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- allow the activity modal to scroll on small screens and adjust spacing
- create reusable circular action button styling
- align edit/delete buttons across task detail, status, collaborator, and topic management views to use the new style

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdcef0aecc83259d3d86c1cb483a7f