### PR TITLE
Atualiza modal de edição com layout moderno

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -663,6 +663,243 @@ body {
   box-shadow: 0 1.25rem 2.5rem rgba(15, 23, 42, 0.25);
 }
 
+.task-form-modal {
+  border: none;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: linear-gradient(180deg, #f9fafe 0%, #ffffff 100%);
+  box-shadow: 0 2rem 3.5rem rgba(12, 21, 56, 0.25);
+}
+
+.task-form-modal__hero {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 2.25rem 2.5rem 1.75rem;
+  background: linear-gradient(135deg, #050b2c 0%, #162a72 58%, #2f48a1 100%);
+  color: #f8faff;
+}
+
+.task-form-modal__hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 50%);
+  pointer-events: none;
+}
+
+.task-form-modal__hero-main {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.task-form-modal__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.95rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.14);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.task-form-modal__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.task-form-modal__subtitle {
+  margin: 0;
+  color: rgba(248, 250, 255, 0.8);
+  font-size: 0.95rem;
+  max-width: 32rem;
+}
+
+.task-form-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.task-form-modal__body {
+  padding: 2rem 2.5rem;
+  display: grid;
+  gap: 1.5rem;
+  background: linear-gradient(180deg, #f3f5ff 0%, #ffffff 100%);
+}
+
+.task-form-modal__section {
+  background: #f8faff;
+  border: 1px solid #e4e9fb;
+  border-radius: 1.25rem;
+  padding: 1.5rem 1.75rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.06);
+}
+
+.task-form-modal__section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 700;
+  color: #162054;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 1.25rem;
+}
+
+.task-form-modal__section-title i {
+  font-size: 1rem;
+  color: #2f48a1;
+}
+
+.task-form-modal .form-control,
+.task-form-modal .form-select {
+  border-radius: 0.85rem;
+  border: 1px solid #dbe1fb;
+  box-shadow: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-form-modal .form-control:focus,
+.task-form-modal .form-select:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.task-form-modal__search .input-group-text {
+  border-radius: 0.85rem 0 0 0.85rem;
+  background: rgba(47, 72, 161, 0.12);
+  border: 1px solid #dbe1fb;
+  border-right: none;
+  color: #2f48a1;
+  font-weight: 600;
+}
+
+.task-form-modal__search .form-control {
+  border-radius: 0 0.85rem 0.85rem 0;
+}
+
+.task-form-modal__dependencies-select {
+  min-height: 11.5rem;
+}
+
+.task-form-modal__notes {
+  min-height: 8rem;
+}
+
+.task-form-modal__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.75rem 2.5rem 2rem;
+  border-top: 1px solid #e7ecff;
+  background: #ffffff;
+}
+
+.task-form-modal__footer-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.task-form-modal__footer-info i {
+  color: #22c55e;
+  font-size: 1.25rem;
+}
+
+.task-form-modal__actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.task-form-modal__actions .btn {
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.65rem 1.5rem;
+  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
+}
+
+.task-form-modal__actions .btn-outline-light {
+  color: #162054;
+  border-color: #dbe1fb;
+  background: #f8faff;
+}
+
+.task-form-modal__actions .btn-outline-light:hover,
+.task-form-modal__actions .btn-outline-light:focus {
+  background: #e8edff;
+  color: #0f172a;
+}
+
+.task-form-modal__submit {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+  border: none;
+}
+
+.task-form-modal__submit:hover,
+.task-form-modal__submit:focus {
+  background: linear-gradient(135deg, #16a34a 0%, #15803d 100%);
+}
+
+.task-form-modal__submit i {
+  font-size: 1rem;
+}
+
+@media (max-width: 991.98px) {
+  .task-form-modal__hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .task-form-modal__close {
+    position: static;
+    align-self: flex-end;
+  }
+
+  .task-form-modal__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .task-form-modal__actions {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .task-form-modal__hero,
+  .task-form-modal__body,
+  .task-form-modal__footer {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .task-form-modal__actions {
+    flex-direction: column-reverse;
+  }
+
+  .task-form-modal__actions .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 @media (max-width: 991.98px) {
   .task-detail-modal__hero {
     grid-template-columns: 1fr;

--- a/assets/js/view/modalView.js
+++ b/assets/js/view/modalView.js
@@ -10,62 +10,120 @@ export const ModalView = {
   init() {
     const modalHtml = `
     <div class="modal fade" id="taskModal" tabindex="-1" aria-labelledby="taskModalLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered modal-lg">
-        <div class="modal-content">
-          <form id="taskForm">
-            <div class="modal-header">
-              <h5 class="modal-title" id="taskModalLabel">Nova Tarefa</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+      <div class="modal-dialog modal-dialog-centered modal-lg modal-dialog-scrollable">
+        <div class="modal-content task-form-modal">
+          <form id="taskForm" class="task-form-modal__form">
+            <div class="task-form-modal__hero">
+              <div class="task-form-modal__hero-main">
+                <span class="task-form-modal__badge">
+                  <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
+                  Gestão de tarefa
+                </span>
+                <h2 class="task-form-modal__title" id="taskModalLabel">Nova Tarefa</h2>
+                <p class="task-form-modal__subtitle">Atualize os dados para manter o cronograma alinhado.</p>
+              </div>
+              <button type="button" class="btn-close btn-close-white task-form-modal__close" data-bs-dismiss="modal" aria-label="Fechar"></button>
             </div>
-            <div class="modal-body row g-3">
-              <div class="col-md-6">
-                <label class="form-label">Título</label>
-                <input type="text" class="form-control" name="title" required>
-              </div>
-              <div class="col-md-6">
-                <label class="form-label">Assunto</label>
-                <select class="form-select" name="topic" required></select>
-              </div>
-              <div class="col-md-6">
-                <label class="form-label">Colaborador</label>
-                <select class="form-select" name="collaborator"></select>
-              </div>
-              <div class="col-12">
-                <label class="form-label">Dependências</label>
-                <div class="dependency-field">
-                  <input type="text" class="form-control mb-2" placeholder="Pesquisar atividades" data-dependency-search>
-                  <select class="form-select" name="dependencies" multiple size="6" data-dependency-options></select>
-                  <div class="form-text">Selecione as atividades que precisam ser concluídas antes desta.</div>
+
+            <div class="task-form-modal__body">
+              <section class="task-form-modal__section">
+                <h6 class="task-form-modal__section-title">
+                  <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+                  Informações principais
+                </h6>
+                <div class="row g-4">
+                  <div class="col-md-6">
+                    <label class="form-label">Título</label>
+                    <input type="text" class="form-control" name="title" required>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Assunto</label>
+                    <select class="form-select" name="topic" required></select>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Colaborador</label>
+                    <select class="form-select" name="collaborator"></select>
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Prioridade</label>
+                    <select class="form-select" name="priority">
+                      <option value="low">Baixa</option>
+                      <option value="medium">Média</option>
+                      <option value="high">Alta</option>
+                    </select>
+                  </div>
                 </div>
-              </div>
-              <div class="col-md-6">
-                <label class="form-label">Data de Início</label>
-                <input type="date" class="form-control" name="startDate">
-              </div>
-              <div class="col-md-6">
-                <label class="form-label">Data Final</label>
-                <input type="date" class="form-control" name="dueDate">
-              </div>
-              <div class="col-md-6">
-                <label class="form-label">Prioridade</label>
-                <select class="form-select" name="priority">
-                  <option value="low">Baixa</option>
-                  <option value="medium">Média</option>
-                  <option value="high">Alta</option>
-                </select>
-              </div>
-              <div class="col-12">
-                <label class="form-label">Tags (separe por vírgulas)</label>
-                <input type="text" class="form-control" name="tags" placeholder="ex: urgente, backend, reunião">
-              </div>
-              <div class="col-12">
-                <label class="form-label">Notas</label>
-                <textarea class="form-control" name="notes" rows="3"></textarea>
-              </div>
+              </section>
+
+              <section class="task-form-modal__section">
+                <h6 class="task-form-modal__section-title">
+                  <i class="fa-solid fa-calendar-days" aria-hidden="true"></i>
+                  Planejamento
+                </h6>
+                <div class="row g-4">
+                  <div class="col-md-6">
+                    <label class="form-label">Data de início</label>
+                    <input type="date" class="form-control" name="startDate">
+                  </div>
+                  <div class="col-md-6">
+                    <label class="form-label">Data final</label>
+                    <input type="date" class="form-control" name="dueDate">
+                  </div>
+                </div>
+              </section>
+
+              <section class="task-form-modal__section">
+                <h6 class="task-form-modal__section-title">
+                  <i class="fa-solid fa-diagram-project" aria-hidden="true"></i>
+                  Dependências
+                </h6>
+                <div class="row g-4 align-items-start">
+                  <div class="col-12 col-lg-5">
+                    <label class="form-label" for="taskDependencySearch">Pesquisar atividades</label>
+                    <div class="input-group task-form-modal__search">
+                      <span class="input-group-text"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></span>
+                      <input type="text" id="taskDependencySearch" class="form-control" placeholder="Digite para filtrar" data-dependency-search>
+                    </div>
+                    <div class="form-text">Use a busca para localizar rapidamente as atividades relacionadas.</div>
+                  </div>
+                  <div class="col-12 col-lg-7">
+                    <label class="form-label" for="taskDependencySelect">Atividades prévias</label>
+                    <select id="taskDependencySelect" class="form-select task-form-modal__dependencies-select" name="dependencies" multiple size="6" data-dependency-options></select>
+                    <div class="form-text">Selecione as atividades que precisam ser concluídas antes desta.</div>
+                  </div>
+                </div>
+              </section>
+
+              <section class="task-form-modal__section">
+                <h6 class="task-form-modal__section-title">
+                  <i class="fa-solid fa-notes-medical" aria-hidden="true"></i>
+                  Contexto adicional
+                </h6>
+                <div class="row g-4">
+                  <div class="col-12">
+                    <label class="form-label">Tags (separe por vírgulas)</label>
+                    <input type="text" class="form-control" name="tags" placeholder="ex: urgente, backend, reunião">
+                  </div>
+                  <div class="col-12">
+                    <label class="form-label">Notas</label>
+                    <textarea class="form-control task-form-modal__notes" name="notes" rows="4"></textarea>
+                  </div>
+                </div>
+              </section>
             </div>
-            <div class="modal-footer">
-              <button type="submit" class="btn btn-success">Salvar</button>
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+
+            <div class="task-form-modal__footer">
+              <div class="task-form-modal__footer-info">
+                <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
+                <span>Mantenha as informações atualizadas para melhorar a visualização.</span>
+              </div>
+              <div class="task-form-modal__actions">
+                <button type="button" class="btn btn-outline-light" data-bs-dismiss="modal">Cancelar</button>
+                <button type="submit" class="btn btn-success task-form-modal__submit">
+                  <i class="fa-solid fa-floppy-disk me-2" aria-hidden="true"></i>
+                  <span data-task-form-submit-label>Salvar</span>
+                </button>
+              </div>
             </div>
           </form>
         </div>
@@ -124,6 +182,18 @@ export const ModalView = {
 
       this.modal.hide();
     });
+  },
+
+  setSubmitButtonText(text) {
+    if (!this.form) return;
+    const submitBtn = this.form.querySelector('button[type="submit"]');
+    if (!submitBtn) return;
+    const labelEl = submitBtn.querySelector('[data-task-form-submit-label]');
+    if (labelEl) {
+      labelEl.textContent = text;
+    } else {
+      submitBtn.textContent = text;
+    }
   },
 
   updateTopicOptions() {
@@ -204,15 +274,14 @@ export const ModalView = {
     this.form.reset();
 
     const title = document.getElementById('taskModalLabel');
-    const submitBtn = this.form.querySelector('button[type="submit"]');
 
     if (this.currentTask) {
       title.textContent = 'Editar Tarefa';
-      submitBtn.textContent = 'Atualizar';
+      this.setSubmitButtonText('Atualizar');
       this.fillForm(this.currentTask);
     } else {
       title.textContent = 'Nova Tarefa';
-      submitBtn.textContent = 'Salvar';
+      this.setSubmitButtonText('Salvar');
     }
 
     this.modal.show();
@@ -253,7 +322,7 @@ export const ModalView = {
     this.currentTask = null;
     this.form.reset();
     document.getElementById('taskModalLabel').textContent = 'Nova Tarefa';
-    this.form.querySelector('button[type="submit"]').textContent = 'Salvar';
+    this.setSubmitButtonText('Salvar');
     this.updateDependencyOptions([]);
     if (this.dependencySearchInput) {
       this.dependencySearchInput.value = '';


### PR DESCRIPTION
## Summary
- moderniza a estrutura do modal de edição de tarefas para refletir o padrão visual do detalhe
- adiciona nova camada de estilos com herói, seções e rodapé temáticos para o formulário
- ajusta a lógica do botão de envio para preservar ícones ao alternar entre criar e editar

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd37d19c88325ad6c96b50d89de5c