### PR TITLE
Enable responsive page scrolling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,6 +1,26 @@
 
+html {
+  height: 100%;
+}
+
 body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
   background-color: #f8f9fa;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+main {
+  flex: 1 0 auto;
+  width: 100%;
+  min-height: 0;
+}
+
+footer {
+  flex-shrink: 0;
+  width: 100%;
 }
 
 .app-header {
@@ -669,6 +689,10 @@ body {
   overflow: hidden;
   background: linear-gradient(180deg, #f9fafe 0%, #ffffff 100%);
   box-shadow: 0 2rem 3.5rem rgba(12, 21, 56, 0.25);
+  display: flex;
+  flex-direction: column;
+  max-height: min(90vh, 62rem);
+  overflow-x: hidden;
 }
 
 .task-form-modal__hero {
@@ -729,11 +753,19 @@ body {
   right: 1rem;
 }
 
+.task-form-modal__hero,
+.task-form-modal__footer {
+  flex-shrink: 0;
+}
+
 .task-form-modal__body {
   padding: 2rem 2.5rem;
   display: grid;
   gap: 1.5rem;
   background: linear-gradient(180deg, #f3f5ff 0%, #ffffff 100%);
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .task-form-modal__section {


### PR DESCRIPTION
## Summary
- allow the task form modal to size itself within the viewport while keeping its layout sections intact
- let the task form body grow and become scrollable so dependency selections remain reachable on smaller screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd6b2da2883259ab1cdc4e190f008