### PR TITLE
Limit status cards per page and refresh board styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,7 +7,13 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background-color: #f8f9fa;
+  background:
+    radial-gradient(circle at top left, rgba(49, 91, 255, 0.12), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(16, 24, 59, 0.18), transparent 55%),
+    linear-gradient(180deg, #f3f5ff 0%, #ffffff 55%, #eff1ff 100%);
+  color: #0f172a;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  line-height: 1.5;
   overflow-x: hidden;
   overflow-y: auto;
 }
@@ -16,11 +22,48 @@ main {
   flex: 1 0 auto;
   width: 100%;
   min-height: 0;
+  padding: 1.5rem 0 3rem;
 }
 
 footer {
   flex-shrink: 0;
   width: 100%;
+}
+
+.nav-tabs {
+  border-bottom: none;
+  gap: 0.5rem;
+}
+
+.nav-tabs .nav-link {
+  border: none;
+  border-radius: 999px;
+  color: #1e293b;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0.65rem 1.25rem rgba(15, 23, 42, 0.08);
+  padding: 0.55rem 1.1rem;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.nav-tabs .nav-link:hover,
+.nav-tabs .nav-link:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 0.9rem 1.8rem rgba(15, 23, 42, 0.12);
+}
+
+.nav-tabs .nav-link.active {
+  color: #fff;
+  background: linear-gradient(135deg, #1b3baa 0%, #2e52d6 100%);
+  box-shadow: 0 1rem 2rem rgba(27, 59, 170, 0.25);
+}
+
+.tab-content {
+  margin-top: 1.5rem;
+}
+
+#calendar-view {
+  margin-top: 2.5rem;
 }
 
 .app-header {
@@ -277,31 +320,84 @@ footer {
   }
 }
 
-.calendar-table th,
-.calendar-table td {
-  width: 14.285%;
+.status-column {
+  display: flex;
 }
 
-.calendar-day-cell {
-  min-height: 120px;
+.status-column__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border: none;
+  border-radius: 1.5rem;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.88) 0%, rgba(243, 245, 255, 0.95) 100%);
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(6px);
+  min-height: 100%;
 }
 
-.calendar-day-cell .badge {
-  white-space: normal;
+.status-column__header {
+  gap: 0.75rem;
+}
+
+.status-column__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #162a72;
+  letter-spacing: 0.02em;
+}
+
+.status-column__count {
+  background: rgba(27, 59, 170, 0.12);
+  color: #1b3baa;
+  font-weight: 700;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+}
+
+.status-column__empty {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 0;
+  border-radius: 1rem;
+  border: 1px dashed rgba(15, 23, 42, 0.12);
+}
+
+.status-column__empty i {
+  font-size: 1.75rem;
+  color: rgba(27, 59, 170, 0.45);
+}
+
+.status-column__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .task-card {
   cursor: pointer;
   border: none;
-  border-radius: 1rem;
-  background: linear-gradient(135deg, #ffffff 0%, #f3f6ff 100%);
-  box-shadow: 0 0.75rem 1.5rem rgba(16, 26, 84, 0.08);
+  border-radius: 1.15rem;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(238, 242, 255, 0.98) 100%);
+  box-shadow: 0 0.9rem 1.9rem rgba(27, 59, 170, 0.08);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .task-card .card-body {
   display: flex;
   flex-direction: column;
+  gap: 0.6rem;
+  padding: 1rem 1.1rem 1.05rem;
+}
+
+.task-card__meta {
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.45rem;
 }
 
@@ -336,13 +432,156 @@ footer {
 .task-card:hover,
 .task-card:focus {
   transform: translateY(-4px);
-  box-shadow: 0 1rem 2rem rgba(16, 26, 84, 0.18);
+  box-shadow: 0 1.15rem 2.2rem rgba(27, 59, 170, 0.18);
   outline: none;
 }
 
 .task-card:focus-visible {
   outline: 3px solid rgba(59, 130, 246, 0.5);
   outline-offset: 4px;
+}
+
+.status-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  margin-top: auto;
+}
+
+.status-pagination__summary {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.status-pagination__controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.status-pagination__controls .btn {
+  border-radius: 999px;
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: rgba(27, 59, 170, 0.12);
+  color: #1b3baa;
+  box-shadow: 0 0.65rem 1.25rem rgba(27, 59, 170, 0.18);
+}
+
+.status-pagination__controls .btn i {
+  font-size: 0.7rem;
+}
+
+.status-pagination__controls .btn:disabled {
+  opacity: 0.45;
+  box-shadow: none;
+}
+
+.status-pagination__controls .btn:not(:disabled):hover,
+.status-pagination__controls .btn:not(:disabled):focus {
+  background: rgba(27, 59, 170, 0.22);
+  color: #0f172a;
+}
+
+.status-pagination__indicator {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #1b3baa;
+}
+
+.calendar-card {
+  border: none;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(245, 247, 255, 0.98) 100%);
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.15);
+  backdrop-filter: blur(6px);
+}
+
+.calendar-card__header {
+  background: linear-gradient(135deg, #152971 0%, #2c4ac9 100%);
+  color: #f8fafc;
+  border-bottom: none;
+  padding: 1.25rem 1.5rem;
+}
+
+.calendar-card__header h5 {
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.calendar-card__header .btn {
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  color: #0f172a;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.2);
+}
+
+.calendar-card__header .btn:hover,
+.calendar-card__header .btn:focus {
+  background: #ffffff;
+  color: #1b3baa;
+}
+
+.calendar-card__body {
+  padding: 0;
+}
+
+.calendar-table {
+  margin-bottom: 0;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.calendar-table thead th {
+  width: 14.285%;
+  border: none;
+  background: transparent;
+  color: #1e293b;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+  padding: 0.9rem 1rem;
+}
+
+.calendar-table tbody td {
+  width: 14.285%;
+  border: none;
+  padding: 1rem 0.9rem;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 -1px 0 rgba(226, 232, 240, 0.6);
+  position: relative;
+}
+
+.calendar-table tbody tr td:not(:last-child) {
+  box-shadow: inset -1px 0 0 rgba(226, 232, 240, 0.6), inset 0 -1px 0 rgba(226, 232, 240, 0.6);
+}
+
+.calendar-day-cell {
+  min-height: 150px;
+  border-radius: 1.1rem;
+}
+
+.calendar-day-cell .badge {
+  white-space: normal;
+  border-radius: 0.85rem;
+  padding: 0.35rem 0.55rem;
+  font-weight: 600;
+}
+
+.calendar-day-cell .badge.text-bg-primary {
+  background: linear-gradient(135deg, #2563eb 0%, #4f46e5 100%) !important;
 }
 
 .task-detail-modal {

--- a/assets/js/view/calendarView.js
+++ b/assets/js/view/calendarView.js
@@ -40,7 +40,7 @@ export const CalendarView = {
     container.innerHTML = '';
 
     const card = document.createElement('div');
-    card.className = 'card shadow-sm';
+    card.className = 'calendar-card card';
 
     card.appendChild(this._buildHeader());
     card.appendChild(this._buildCalendarBody());
@@ -50,11 +50,11 @@ export const CalendarView = {
 
   _buildHeader() {
     const header = document.createElement('div');
-    header.className = 'card-header d-flex justify-content-between align-items-center';
+    header.className = 'calendar-card__header card-header d-flex justify-content-between align-items-center';
 
     const prevBtn = document.createElement('button');
     prevBtn.type = 'button';
-    prevBtn.className = 'btn btn-sm btn-outline-secondary';
+    prevBtn.className = 'btn btn-sm';
     prevBtn.textContent = '‹ Mês anterior';
     prevBtn.addEventListener('click', () => {
       this.render(addMonths(this.currentMonth, -1), this.currentTopic);
@@ -67,7 +67,7 @@ export const CalendarView = {
 
     const nextBtn = document.createElement('button');
     nextBtn.type = 'button';
-    nextBtn.className = 'btn btn-sm btn-outline-secondary';
+    nextBtn.className = 'btn btn-sm';
     nextBtn.textContent = 'Próximo mês ›';
     nextBtn.addEventListener('click', () => {
       this.render(addMonths(this.currentMonth, 1), this.currentTopic);
@@ -82,10 +82,10 @@ export const CalendarView = {
 
   _buildCalendarBody() {
     const body = document.createElement('div');
-    body.className = 'card-body p-0';
+    body.className = 'calendar-card__body card-body';
 
     const table = document.createElement('table');
-    table.className = 'table table-bordered table-sm mb-0 calendar-table align-middle';
+    table.className = 'table calendar-table align-middle';
 
     table.appendChild(this._buildTableHead());
     table.appendChild(this._buildTableBody());

--- a/assets/js/view/listView.js
+++ b/assets/js/view/listView.js
@@ -1,7 +1,11 @@
 import { TaskModel } from '../model/taskModel.js';
 import { EventBus } from '../core/eventBus.js';
 
+const PAGE_SIZE = 3;
+
 export const ListView = {
+  pageState: new Map(),
+
   render(currentTopic = 'Todos') {
     const content = document.getElementById('tab-content');
     content.innerHTML = '';
@@ -28,88 +32,172 @@ export const ListView = {
 
     statuses.forEach(status => {
       const col = document.createElement('div');
-      col.className = 'col-md-4 mb-3';
+      col.className = 'col-md-4 mb-4 status-column';
 
       const box = document.createElement('div');
-      box.className = 'border rounded bg-white shadow-sm p-2';
+      box.className = 'status-column__card h-100';
 
-      const header = document.createElement('h6');
-      header.textContent = status.label;
-      header.className = 'text-primary border-bottom pb-1 mb-2';
+      const statusTasks = filtered.filter(t => t.status === status.id);
+      const totalPages = Math.max(1, Math.ceil(statusTasks.length / PAGE_SIZE));
+      const stateKey = `${currentTopic}::${status.id}`;
+      let currentPage = this.pageState.get(stateKey) || 1;
 
+      if (currentPage > totalPages) {
+        currentPage = totalPages;
+      }
+
+      this.pageState.set(stateKey, currentPage);
+
+      const header = document.createElement('div');
+      header.className = 'status-column__header d-flex justify-content-between align-items-start';
+
+      const headerTitle = document.createElement('h6');
+      headerTitle.textContent = status.label;
+      headerTitle.className = 'status-column__title mb-0';
+
+      const headerCount = document.createElement('span');
+      headerCount.className = 'status-column__count badge';
+      headerCount.textContent = statusTasks.length;
+
+      header.appendChild(headerTitle);
+      header.appendChild(headerCount);
       box.appendChild(header);
 
-      filtered.filter(t => t.status === status.id).forEach(task => {
-        const card = document.createElement('div');
+      if (statusTasks.length === 0) {
+        const emptyState = document.createElement('div');
+        emptyState.className = 'status-column__empty text-center text-muted';
+        emptyState.innerHTML = `
+          <i class="fa-regular fa-circle-check"></i>
+          <p class="mb-0">Sem atividades</p>
+        `;
+        box.appendChild(emptyState);
+      } else {
+        const startIndex = (currentPage - 1) * PAGE_SIZE;
+        const visibleTasks = statusTasks.slice(startIndex, startIndex + PAGE_SIZE);
 
-        card.className = 'card mb-2 task-card';
-        card.tabIndex = 0;
-        card.setAttribute('role', 'button');
+        const list = document.createElement('div');
+        list.className = 'status-column__list';
 
-        const body = document.createElement('div');
-        body.className = 'card-body p-2';
+        visibleTasks.forEach(task => {
+          const card = document.createElement('div');
 
-        const title = document.createElement('h6');
-        title.className = 'card-title mb-1';
-        title.textContent = task.title;
+          card.className = 'card task-card';
+          card.tabIndex = 0;
+          card.setAttribute('role', 'button');
 
-        const date = document.createElement('small');
-        date.className = 'text-muted';
-        date.textContent = task.dueDate || 'Sem data';
+          const body = document.createElement('div');
+          body.className = 'card-body';
 
-        const meta = document.createElement('div');
-        meta.className = 'mt-1 d-flex flex-wrap gap-1';
+          const title = document.createElement('h6');
+          title.className = 'card-title mb-1';
+          title.textContent = task.title;
 
-        const topicBadge = document.createElement('span');
-        topicBadge.className = 'badge bg-secondary';
-        topicBadge.textContent = task.topic;
+          const date = document.createElement('small');
+          date.className = 'text-muted';
+          date.textContent = task.dueDate || 'Sem data';
 
-        const priorityBadge = document.createElement('span');
-        const priorityClasses = {
-          high: 'badge bg-danger',
-          medium: 'badge bg-warning text-dark',
-          low: 'badge bg-light text-dark'
-        };
-        priorityBadge.className = priorityClasses[task.priority] || 'badge bg-light text-dark';
-        priorityBadge.textContent = task.priority;
+          const meta = document.createElement('div');
+          meta.className = 'task-card__meta';
 
-        meta.appendChild(topicBadge);
-        meta.appendChild(priorityBadge);
+          const topicBadge = document.createElement('span');
+          topicBadge.className = 'badge bg-secondary';
+          topicBadge.textContent = task.topic;
 
-        if (task.collaborator) {
-          const collaboratorBadge = document.createElement('span');
-          collaboratorBadge.className = 'badge bg-info text-dark';
-          collaboratorBadge.textContent = task.collaborator;
-          meta.appendChild(collaboratorBadge);
-        }
+          const priorityBadge = document.createElement('span');
+          const priorityClasses = {
+            high: 'badge bg-danger',
+            medium: 'badge bg-warning text-dark',
+            low: 'badge bg-light text-dark'
+          };
+          priorityBadge.className = priorityClasses[task.priority] || 'badge bg-light text-dark';
+          priorityBadge.textContent = task.priority;
 
-        if (Array.isArray(task.dependencies) && task.dependencies.length > 0) {
-          const dependencyBadge = document.createElement('span');
-          dependencyBadge.className = 'badge bg-light text-dark border';
-          const count = task.dependencies.length;
-          dependencyBadge.textContent = count === 1
-            ? '1 dependência'
-            : `${count} dependências`;
-          meta.appendChild(dependencyBadge);
-        }
+          meta.appendChild(topicBadge);
+          meta.appendChild(priorityBadge);
 
-        body.appendChild(title);
-        body.appendChild(date);
-        body.appendChild(meta);
-
-        card.appendChild(body);
-        card.addEventListener('click', () => {
-          EventBus.emit('openTaskDetail', task);
-        });
-        card.addEventListener('keydown', (event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            EventBus.emit('openTaskDetail', task);
+          if (task.collaborator) {
+            const collaboratorBadge = document.createElement('span');
+            collaboratorBadge.className = 'badge bg-info text-dark';
+            collaboratorBadge.textContent = task.collaborator;
+            meta.appendChild(collaboratorBadge);
           }
+
+          if (Array.isArray(task.dependencies) && task.dependencies.length > 0) {
+            const dependencyBadge = document.createElement('span');
+            dependencyBadge.className = 'badge bg-light text-dark border';
+            const count = task.dependencies.length;
+            dependencyBadge.textContent = count === 1
+              ? '1 dependência'
+              : `${count} dependências`;
+            meta.appendChild(dependencyBadge);
+          }
+
+          body.appendChild(title);
+          body.appendChild(date);
+          body.appendChild(meta);
+
+          card.appendChild(body);
+          card.addEventListener('click', () => {
+            EventBus.emit('openTaskDetail', task);
+          });
+          card.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              EventBus.emit('openTaskDetail', task);
+            }
+          });
+
+          list.appendChild(card);
         });
 
-        box.appendChild(card);
-      });
+        box.appendChild(list);
+
+        if (totalPages > 1) {
+          const pagination = document.createElement('div');
+          pagination.className = 'status-pagination';
+
+          const summary = document.createElement('span');
+          summary.className = 'status-pagination__summary';
+          const endItem = Math.min(startIndex + PAGE_SIZE, statusTasks.length);
+          summary.textContent = `Mostrando ${startIndex + 1}-${endItem} de ${statusTasks.length}`;
+
+          const controls = document.createElement('div');
+          controls.className = 'status-pagination__controls';
+
+          const prevBtn = document.createElement('button');
+          prevBtn.type = 'button';
+          prevBtn.className = 'btn btn-sm';
+          prevBtn.innerHTML = '<i class="fa-solid fa-chevron-left"></i>';
+          prevBtn.disabled = currentPage === 1;
+          prevBtn.addEventListener('click', () => {
+            this.pageState.set(stateKey, currentPage - 1);
+            this.render(currentTopic);
+          });
+
+          const pageIndicator = document.createElement('span');
+          pageIndicator.className = 'status-pagination__indicator';
+          pageIndicator.textContent = `${currentPage}/${totalPages}`;
+
+          const nextBtn = document.createElement('button');
+          nextBtn.type = 'button';
+          nextBtn.className = 'btn btn-sm';
+          nextBtn.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
+          nextBtn.disabled = currentPage === totalPages;
+          nextBtn.addEventListener('click', () => {
+            this.pageState.set(stateKey, currentPage + 1);
+            this.render(currentTopic);
+          });
+
+          controls.appendChild(prevBtn);
+          controls.appendChild(pageIndicator);
+          controls.appendChild(nextBtn);
+
+          pagination.appendChild(summary);
+          pagination.appendChild(controls);
+
+          box.appendChild(pagination);
+        }
+      }
 
       col.appendChild(box);
       row.appendChild(col);


### PR DESCRIPTION
## Summary
- cap the visible cards in each status column to three items and paginate the overflow
- refresh the task board appearance with modernized cards, navigation pills, and empty states
- update the calendar view styling and controls to match the new visual language

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cddf83364c8325a87d060085e43878